### PR TITLE
Fix: 3 security advisories (permissao bitmask, gateway de pagamento, XSS em sucesso.php)

### DIFF
--- a/web/html/contribuicao/controller/control.php
+++ b/web/html/contribuicao/controller/control.php
@@ -112,6 +112,14 @@ try {
 
         switch ($controller) {
             case 'GatewayPagamentoController':
+                // Recurso 9 (Configurações) — mesmo recurso já exigido pela
+                // própria tela (view/gateway_pagamento.php). Não pode ficar
+                // no recurso 7 (Contribuições): um operador com acesso apenas
+                // a registrar boletos/sincronizar pagamentos (nível 3 do
+                // recurso 7) conseguia repontar o endpoint do gateway e
+                // capturar dados de cartão + a chave de API do provedor.
+                $id_recurso = 9;
+                break;
             case 'MeioPagamentoController':
             case 'RegraPagamentoController':
                 $id_recurso = 7; // Recurso de contribuições

--- a/web/html/contribuicao/dao/GatewayPagamentoDAO.php
+++ b/web/html/contribuicao/dao/GatewayPagamentoDAO.php
@@ -127,6 +127,23 @@ class GatewayPagamentoDAO
         }
     }
 
+    /**
+     * Busca só o endpoint atualmente cadastrado para o gateway, independente
+     * do status (ativo ou não) — usado por GatewayPagamento::editar() pra
+     * detectar troca de endpoint mesmo em gateways desativados.
+     */
+    public function buscarEndpointPorId($id)
+    {
+        $sql = "SELECT endpoint FROM contribuicao_gatewayPagamento WHERE id=:id";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->bindParam(':id', $id);
+        $stmt->execute();
+
+        $resultado = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $resultado ? $resultado['endpoint'] : null;
+    }
+
     public function buscarPorId($id)
     {
         //definir consulta sql

--- a/web/html/contribuicao/model/GatewayPagamento.php
+++ b/web/html/contribuicao/model/GatewayPagamento.php
@@ -37,9 +37,22 @@ class GatewayPagamento
     {
         require_once '../dao/GatewayPagamentoDAO.php';
         $gatewayPagamentoDao = new GatewayPagamentoDAO();
-        
+
         // Verifica se o token informado está ofuscado (possui apenas asteriscos ou é parcialmente ofuscado)
         if (strpos($this->token, '*') !== false) {
+            // Token não foi reinformado (veio ofuscado da tela). Se o endpoint
+            // estiver mudando mesmo assim, recusa: sem essa checagem, dava pra
+            // redirecionar as cobranças pra um servidor de terceiros mantendo
+            // a credencial real intacta no banco — o token real seguiria
+            // sendo enviado, agora pro host do atacante.
+            $endpointAtual = $gatewayPagamentoDao->buscarEndpointPorId($this->id);
+
+            if ($endpointAtual !== null && $endpointAtual !== $this->endpoint) {
+                throw new InvalidArgumentException(
+                    'Para alterar o endpoint do gateway é necessário reinformar o Token API — ele não pode continuar ofuscado.'
+                );
+            }
+
             // Não atualiza o token se ele estiver ofuscado
             $gatewayPagamentoDao->editarPorId($this->id, $this->nome, $this->endpoint, null);
         } else {
@@ -122,7 +135,14 @@ class GatewayPagamento
             throw new InvalidArgumentException('O endpoint de um gateway de pagamento não pode ser vazio.');
         }
 
-        $this->endpoint = $endpoint;
+        // Exige URL válida em HTTPS: sem isso, um endpoint como
+        // "http://attacker.tld/collect" seria aceito, e a credencial do
+        // gateway (token) trafegaria em texto claro pro atacante.
+        if (!filter_var($endpointLimpo, FILTER_VALIDATE_URL) || stripos($endpointLimpo, 'https://') !== 0) {
+            throw new InvalidArgumentException('O endpoint do gateway deve ser uma URL HTTPS válida.');
+        }
+
+        $this->endpoint = $endpointLimpo;
 
         return $this;
     }

--- a/web/html/permissao/permissao.php
+++ b/web/html/permissao/permissao.php
@@ -37,7 +37,17 @@ function permissao($id_pessoa, $id_recurso, $id_acao = 1): void
 		if (!$permissao)
 			throw new LogicException("Usuário não possui permissão para acessar o recurso {$id_recurso}", 403);
 
-		if ($permissao['id_acao'] < $id_acao)
+		// id_acao é uma bitmask (1=SEM ACESSO, 3=GRAVAR E EXECUTAR, 5=LER E
+		// EXECUTAR, 7=LER, GRAVAR E EXECUTAR), não um ranking — "<" deixava
+		// passar, por exemplo, um cargo com 5 (leitura) por uma exigência de 3
+		// (escrita), e principalmente deixava 1 (SEM ACESSO) passar sempre que
+		// a chamada usava o nível padrão (também 1, "1 < 1" é falso). Por isso
+		// SEM ACESSO é tratado como negação explícita, e o restante é
+		// verificado via bitwise AND (o cargo precisa ter TODOS os bits
+		// exigidos, não apenas um valor numericamente maior).
+		$idAcaoConcedido = (int) $permissao['id_acao'];
+
+		if ($idAcaoConcedido === 1 || ($idAcaoConcedido & $id_acao) !== $id_acao)
 			throw new LogicException("Usuário não possui permissão para realizar a ação {$id_acao} no recurso {$id_recurso}", 403);
 	} catch (Exception $e) {
 		//Armazena exceção em um arquivo de log

--- a/web/html/sucesso.php
+++ b/web/html/sucesso.php
@@ -13,10 +13,8 @@ if (file_exists($config_path)) {
 session_start();
 if (!isset($_SESSION['usuario'])) {
 	header("Location: ../index.php");
+	exit();
 }
-
-extract($_REQUEST);
-
 
 
 // Adiciona a Função display_campo($nome_campo, $tipo_campo)
@@ -117,7 +115,7 @@ require_once "personalizacao_display.php";
 			</header>
 			<section role="main" class="content-body">
 
-				<div class="alert alert-success" style="font-size: 15px;"><i class="fas fa-check mr-md"></i><?php echo $_SESSION['msg']; ?><br><a href=<?php echo "'" . $_SESSION['link'] . "'"; ?>><?php echo $_SESSION['proxima']; ?></a>
+				<div class="alert alert-success" style="font-size: 15px;"><i class="fas fa-check mr-md"></i><?php echo htmlspecialchars($_SESSION['msg'] ?? ''); ?><br><a href="<?php echo htmlspecialchars($_SESSION['link'] ?? '#'); ?>"><?php echo htmlspecialchars($_SESSION['proxima'] ?? ''); ?></a>
 				</div>
 			</section>
 


### PR DESCRIPTION
## Resumo

Corrige 3 dos 4 security advisories privados (draft) reportados em 03/08/2026. Cada advisory foi corrigido em um commit separado, com validação real contra o banco de dados (não apenas revisão de código).

### [GHSA-fq5p-pjvq-7qxf](https://github.com/LabRedesCefetRJ/WeGIA/security/advisories/GHSA-fq5p-pjvq-7qxf) — `permissao()` trata bitmask como ranking (High, CVSS 8.8)
`id_acao` é uma bitmask (1=SEM ACESSO, 3=GRAVAR E EXECUTAR, 5=LER E EXECUTAR, 7=LER GRAVAR EXECUTAR), mas o gate comparava com `<`. Isso deixava passar um cargo com 5 (leitura) por uma exigência de 3 (escrita), e principalmente deixava **SEM ACESSO (1) passar sempre** que a chamada usava o nível padrão — afetando 23 pontos do código, incluindo `exportar_dump.php` e `gerenciar_backup.php` no módulo de Configurações.

Corrigido: SEM ACESSO nega explicitamente; o restante verifica via bitwise AND.

### [GHSA-cvwg-5rhv-q8pv](https://github.com/LabRedesCefetRJ/WeGIA/security/advisories/GHSA-cvwg-5rhv-q8pv) — Gateway de pagamento no recurso errado + bypass do token mascarado (High, CVSS 8.1)
`GatewayPagamentoController` era autorizado contra o recurso 7 (Contribuições, nível operacional) em vez do recurso 9 (Configurações) que a própria tela exige. Combinado com isso, `GatewayPagamento::editar()` permitia trocar o `endpoint` do gateway mantendo o token mascarado (`***`) — redirecionando cobranças (número de cartão, CVV) e a chave de API real pra um servidor de terceiros.

Corrigido: recurso exigido corrigido pra 9; edição recusa mudar o endpoint sem reinformar o token real; endpoint agora exige HTTPS válido.

### [GHSA-qx7r-ffrg-8hxq](https://github.com/LabRedesCefetRJ/WeGIA/security/advisories/GHSA-qx7r-ffrg-8hxq) — XSS refletido via `extract($_REQUEST)` em `sucesso.php` (Medium)
O gate de sessão não tinha `exit()`, e `extract($_REQUEST)` permitia sobrescrever a superglobal `$_SESSION` via querystring (chave literal `_SESSION[...]`), com output sem escape — RCE de JavaScript no contexto da aplicação contra vítimas autenticadas.

Corrigido: `extract($_REQUEST)` removido, `exit()` adicionado após o redirect, output escapado com `htmlspecialchars()`.

### GHSA-26v7-7qw6-p7f2 — sem commit novo
O arquivo vulnerável (`docfamiliar_upload.php`) já havia sido removido por completo em um commit anterior já mesclado no master (`1c2cd118`, refs `GHSA-9grh-ch4x-xq8c`). Confirmado que o arquivo continua ausente e nada mais no repositório referencia esse caminho.

## Test plan

- [x] `php -l` em todos os arquivos alterados
- [x] `permissao()`: testada de ponta a ponta contra o banco real (pessoa/cargo/funcionário/permissão descartáveis), reproduzindo a matriz de decisão completa do relatório — SEM ACESSO sempre negado, cargo-leitura corretamente negado numa exigência de escrita, nenhum cargo legítimo perdeu acesso
- [x] Gateway de pagamento: testado com banco isolado — PoC exato do relatório (endpoint trocado + token mascarado) recusado; edição legítima (token mascarado, endpoint igual) permitida; reenvio do token real com novo endpoint permitido; endpoint `http://` recusado; operador com apenas recurso 7 nível 3 confirmadamente bloqueado do `GatewayPagamentoController` mas mantém acesso normal a `MeioPagamentoController`/`RegraPagamentoController`
- [x] `sucesso.php`: simulada sessão autenticada real + payload exato do PoC — `$_SESSION` não é mais sobrescrito, payload não aparece no HTML, fluxo legítimo de mensagem de sucesso preservado
- [x] Testes manuais no navegador (módulo Configurações, tela de Gateway de Pagamento, fluxos que retornam para `sucesso.php`: Cargos, Documentos de Funcionário, Tags de Sócio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)