### PR TITLE
Fix: acessibilidade WCAG no módulo Funcionário

### DIFF
--- a/web/html/funcionario/cadastro_dependente_pessoa_nova.php
+++ b/web/html/funcionario/cadastro_dependente_pessoa_nova.php
@@ -53,7 +53,7 @@ $fieldErrors = getSessionFormErrors();
 
 ?>
 <!DOCTYPE html>
-<html class="fixed">
+<html class="fixed" lang="pt-br">
 
 <head>
 
@@ -61,7 +61,7 @@ $fieldErrors = getSessionFormErrors();
   <meta charset="UTF-8">
   <title>Cadastro de Funcionário</title>
   <!-- Mobile Metas -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- Web Fonts  -->
   <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800|Shadows+Into+Light" rel="stylesheet" type="text/css">
@@ -107,7 +107,7 @@ $fieldErrors = getSessionFormErrors();
             <li><span>Cadastros</span></li>
             <li><span>Dependentes</span></li>
           </ol>
-          <a class="sidebar-right-toggle"><i class="fa fa-chevron-left"></i></a>
+          <a class="sidebar-right-toggle" aria-label="Alternar painel lateral"><i class="fa fa-chevron-left"></i></a>
         </div>
       </header>
 
@@ -125,7 +125,7 @@ $fieldErrors = getSessionFormErrors();
                 <h4 class="mb-xlg">Informações Pessoais</h4>
                 <h5 class="obrig">Campos Obrigatórios(*)</h5>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileFirstName">Nome<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="nome">Nome<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="text" class="form-control<?= !empty($fieldErrors['nome']) ? ' is-invalid' : '' ?>" name="nome" id="nome" onkeypress="return Onlychars(event)" value="<?= htmlspecialchars($oldInput['nome'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                     <?php if (!empty($fieldErrors['nome'])): ?>
@@ -134,7 +134,7 @@ $fieldErrors = getSessionFormErrors();
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label">Sobrenome<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="sobrenome">Sobrenome<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="text" class="form-control<?= !empty($fieldErrors['sobrenome']) ? ' is-invalid' : '' ?>" name="sobrenome" id="sobrenome" onkeypress="return Onlychars(event)" value="<?= htmlspecialchars($oldInput['sobrenome'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                     <?php if (!empty($fieldErrors['sobrenome'])): ?>
@@ -143,10 +143,10 @@ $fieldErrors = getSessionFormErrors();
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileLastName">Sexo<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label">Sexo<sup class="obrig">*</sup></label>
                   <div class="col-md-8">
-                    <label><input type="radio" name="sexo" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()" required <?= ($oldInput['sexo'] ?? '') === 'm' ? 'checked' : '' ?>><i class="fa fa-male" style="font-size: 20px;"></i></label>
-                    <label><input type="radio" name="sexo" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()" <?= ($oldInput['sexo'] ?? '') === 'f' ? 'checked' : '' ?>><i class="fa fa-female" style="font-size: 20px;"></i> </label>
+                    <label><input type="radio" name="sexo" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()" required aria-label="Masculino" <?= ($oldInput['sexo'] ?? '') === 'm' ? 'checked' : '' ?>><i class="fa fa-male" style="font-size: 20px;"></i></label>
+                    <label><input type="radio" name="sexo" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()" aria-label="Feminino" <?= ($oldInput['sexo'] ?? '') === 'f' ? 'checked' : '' ?>><i class="fa fa-female" style="font-size: 20px;"></i> </label>
                   </div>
                 </div>
                 <div class="form-group">
@@ -167,7 +167,7 @@ $fieldErrors = getSessionFormErrors();
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Nascimento<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="nascimento">Nascimento<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="date" placeholder="dd/mm/aaaa" maxlength="10" class="form-control" name="nascimento" id="nascimento" max=<?php echo date('Y-m-d'); ?> value="<?= htmlspecialchars($oldInput['nascimento'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                   </div>
@@ -187,7 +187,7 @@ $fieldErrors = getSessionFormErrors();
                       }
                       ?>
                     </select>
-                    <a onclick="adicionarParentesco()" style="margin: 0 20px;"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                    <a onclick="adicionarParentesco()" style="margin: 0 20px;" aria-label="Adicionar parentesco"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                   </div>
                 </div>
                 <hr class="dotted short">
@@ -202,19 +202,19 @@ $fieldErrors = getSessionFormErrors();
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Número do RG</label>
+                  <label class="col-md-3 control-label" for="rg">Número do RG</label>
                   <div class="col-md-6">
                     <input type="text" class="form-control" name="rg" id="rg" onkeypress="return Onlynumbers(event)" placeholder="Ex: 22.222.222-2" onkeyup="mascara('##.###.###-#',this,event)">
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Órgão Emissor</label>
+                  <label class="col-md-3 control-label" for="orgao_emissor">Órgão Emissor</label>
                   <div class="col-md-6">
                     <input type="text" class="form-control" name="orgao_emissor" id="orgao_emissor" onkeypress="return Onlychars(event)">
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Data de expedição</label>
+                  <label class="col-md-3 control-label" for="data_expedicao">Data de expedição</label>
                   <div class="col-md-6">
                     <input type="date" class="form-control" maxlength="10" placeholder="dd/mm/aaaa" name="data_expedicao" id="data_expedicao" max=<?php echo date('Y-m-d'); ?> disabled>
                     <p id="dataNascInvalida" style="display: block; color: #b30000">Selecione a data de nascimento primeiro!</p>
@@ -588,7 +588,7 @@ $fieldErrors = getSessionFormErrors();
   <script src="../../assets/vendor/jquery-placeholder/jquery.placeholder.js"></script>
 
   <div align="right">
-    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;"></iframe>
+    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
   </div>
 </body>
 

--- a/web/html/funcionario/cadastro_funcionario.php
+++ b/web/html/funcionario/cadastro_funcionario.php
@@ -52,14 +52,14 @@ $cargo = $mysqli->query("SELECT * FROM cargo");
 require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'Csrf.php';
 ?>
 <!DOCTYPE html>
-<html class="fixed">
+<html class="fixed" lang="pt-br">
 
 <head>
   <!-- Basic -->
   <meta charset="UTF-8">
   <title>Cadastro de Funcionário</title> 
   <!-- Mobile Metas -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- Web Fonts  -->
   <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800|Shadows+Into+Light" rel="stylesheet" type="text/css">
@@ -111,7 +111,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
             <li><span>Cadastros</span></li>
             <li><span>Funcionário</span></li>
           </ol>
-          <a class="sidebar-right-toggle"><i class="fa fa-chevron-left"></i></a>
+          <a class="sidebar-right-toggle" aria-label="Alternar painel lateral"><i class="fa fa-chevron-left"></i></a>
         </div>
       </header>
       <!-- start: page -->
@@ -137,6 +137,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                   }
                   ?>
 
+                  <label for="imgform" class="sr-only">Carregar imagem de perfil</label>
                   <input type="file" class="image_input form-control" onclick="okDisplay()" name="imgperfil" id="imgform">
                   <div id="display_image" class="thumb-info mb-md"></div>
                   <div id="botima">
@@ -166,7 +167,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                   <h4 class="mb-xlg">Informações Pessoais</h4>
                   <h5 class="obrig">Campos Obrigatórios(*)</h5>
                   <div class="form-group">
-                    <label class="col-md-3 control-label" for="profileFirstName">Nome<sup class="obrig">*</sup></label>
+                    <label class="col-md-3 control-label" for="nome">Nome<sup class="obrig">*</sup></label>
                     <div class="col-md-6">
                       <input type="text" class="form-control<?= isset($fieldErrors['nome']) ? ' is-invalid' : '' ?>" name="nome" id="nome" onkeypress="return Onlychars(event)" required value="<?= htmlspecialchars($oldInput['nome'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                       <p id="error_nome" class="help-block text-danger" style="display: <?= isset($fieldErrors['nome']) ? 'block' : 'none' ?>;">
@@ -175,7 +176,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label">Sobrenome<sup class="obrig">*</sup></label>
+                    <label class="col-md-3 control-label" for="sobrenome">Sobrenome<sup class="obrig">*</sup></label>
                     <div class="col-md-6">
                       <input type="text" class="form-control<?= isset($fieldErrors['sobrenome']) ? ' is-invalid' : '' ?>" name="sobrenome" id="sobrenome" onkeypress="return Onlychars(event)" required value="<?= htmlspecialchars($oldInput['sobrenome'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                       <p id="error_sobrenome" class="help-block text-danger" style="display: <?= isset($fieldErrors['sobrenome']) ? 'block' : 'none' ?>;">
@@ -184,10 +185,10 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label" for="profileLastName">Sexo<sup class="obrig">*</sup></label>
+                    <label class="col-md-3 control-label">Sexo<sup class="obrig">*</sup></label>
                     <div class="col-md-6">
-                      <label><input type="radio" name="gender" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()" required <?= isset($oldInput['gender']) && $oldInput['gender'] === 'm' ? 'checked' : '' ?>><i class="fa fa-male" style="font-size: 20px;"></i></label>
-                      <label><input type="radio" name="gender" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()" <?= isset($oldInput['gender']) && $oldInput['gender'] === 'f' ? 'checked' : '' ?>><i class="fa fa-female" style="font-size: 20px;"></i> </label>
+                      <label><input type="radio" name="gender" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()" required aria-label="Masculino" <?= isset($oldInput['gender']) && $oldInput['gender'] === 'm' ? 'checked' : '' ?>><i class="fa fa-male" style="font-size: 20px;"></i></label>
+                      <label><input type="radio" name="gender" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()" aria-label="Feminino" <?= isset($oldInput['gender']) && $oldInput['gender'] === 'f' ? 'checked' : '' ?>><i class="fa fa-female" style="font-size: 20px;"></i> </label>
                     </div>
                   </div>
                   <div class="form-group">
@@ -207,7 +208,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label" for="profileCompany">Nascimento<sup class="obrig">*</sup></label>
+                    <label class="col-md-3 control-label" for="nascimento">Nascimento<sup class="obrig">*</sup></label>
                     <div class="col-md-6">
                       <input type="date" name="nascimento" id="nascimento" class="form-control<?= isset($fieldErrors['nascimento']) ? ' is-invalid' : '' ?>" min="<?= $dataNascimentoMinima ?>" max="<?= $dataNascimentoMaxima ?>" required value="<?= htmlspecialchars($oldInput['nascimento'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                       <p id="error_nascimento" class="help-block text-danger" style="display: <?= isset($fieldErrors['nascimento']) ? 'block' : 'none' ?>;">
@@ -227,7 +228,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
 
                  <div id="grupoRG">
                     <div class="form-group">
-                      <label class="col-md-3 control-label">Número do RG</label>
+                      <label class="col-md-3 control-label" for="rg">Número do RG</label>
                       <div class="col-md-6">
                         <input type="text" class="form-control<?= isset($fieldErrors['rg']) ? ' is-invalid' : '' ?>" name="rg" id="rg"
                           onkeypress="return Onlynumbers(event)"
@@ -240,7 +241,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
 
                     <div class="form-group">
-                      <label class="col-md-3 control-label">Órgão Emissor</label>
+                      <label class="col-md-3 control-label" for="orgao_emissor">Órgão Emissor</label>
                       <div class="col-md-6">
                         <input type="text" class="form-control<?= isset($fieldErrors['orgao_emissor']) ? ' is-invalid' : '' ?>" name="orgao_emissor" id="orgao_emissor"
                           onkeypress="return Onlychars(event)" value="<?= htmlspecialchars($oldInput['orgao_emissor'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
@@ -254,7 +255,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
 
                     <div class="form-group">
-                      <label class="col-md-3 control-label">Data de expedição</label>
+                      <label class="col-md-3 control-label" for="data_expedicao">Data de expedição</label>
                       <div class="col-md-6">
                         <input type="date" class="form-control<?= isset($fieldErrors['data_expedicao']) ? ' is-invalid' : '' ?>"
                           name="data_expedicao" id="data_expedicao"
@@ -290,7 +291,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label" for="profileCompany">Data de Admissão<sup class="obrig">*</sup></label>
+                    <label class="col-md-3 control-label" for="data_admissao">Data de Admissão<sup class="obrig">*</sup></label>
                     <div class="col-md-6">
                       <input type="date" class="form-control<?= isset($fieldErrors['data_admissao']) ? ' is-invalid' : '' ?>"
                         name="data_admissao"
@@ -303,8 +304,8 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label" for="inputSuccess">Situação<sup class="obrig">*</sup></label>
-                    <a onclick="adicionar_situacao()"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                    <label class="col-md-3 control-label" for="situacao">Situação<sup class="obrig">*</sup></label>
+                    <a onclick="adicionar_situacao()" aria-label="Adicionar situação"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                     <div class="col-md-6">
                       <select class="form-control input-lg mb-md<?= isset($fieldErrors['situacao']) ? ' is-invalid' : '' ?>" name="situacao" id="situacao" required>
                         <option selected disabled>Selecionar</option>
@@ -320,8 +321,8 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label" for="inputSuccess">Cargo<sup class="obrig">*</sup></label>
-                    <a onclick="adicionar_cargo()"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                    <label class="col-md-3 control-label" for="cargo">Cargo<sup class="obrig">*</sup></label>
+                    <a onclick="adicionar_cargo()" aria-label="Adicionar cargo"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                     <div class="col-md-6">
                       <select class="form-control input-lg mb-md<?= isset($fieldErrors['cargo']) ? ' is-invalid' : '' ?>" name="cargo" id="cargo" required>
                         <option selected disabled>Selecionar</option>
@@ -338,7 +339,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label">Escala<sup class="obrig">*</sup></label>
+                    <label class="col-md-3 control-label" for="escala_input">Escala<sup class="obrig">*</sup></label>
                     <div class="col-md-6">
                       <select class="form-control input-lg mb-md" name="escala" id="escala_input" required>
                         <option selected disabled value="">Selecionar</option>
@@ -352,10 +353,10 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                         ?>
                       </select>
                     </div>
-                    <a href="../quadro_horario/adicionar_escala.php"><i class="fas fa-plus w3-xlarge"></i></a>
+                    <a href="../quadro_horario/adicionar_escala.php" aria-label="Adicionar escala"><i class="fas fa-plus w3-xlarge"></i></a>
                   </div>
                   <div class="form-group">
-                    <label class="col-md-3 control-label">Tipo<sup class="obrig">*</sup></label>
+                    <label class="col-md-3 control-label" for="tipoCargaHoraria_input">Tipo<sup class="obrig">*</sup></label>
                     <div class="col-md-6">
                       <select class="form-control input-lg mb-md" name="tipoCargaHoraria" id="tipoCargaHoraria_input" required>
                         <option selected disabled value="">Selecionar</option>
@@ -369,7 +370,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                         ?>
                       </select>
                     </div>
-                    <a href="../quadro_horario/adicionar_tipo_quadro_horario.php"><i class="fas fa-plus w3-xlarge"></i></a>
+                    <a href="../quadro_horario/adicionar_tipo_quadro_horario.php" aria-label="Adicionar tipo de carga horária"><i class="fas fa-plus w3-xlarge"></i></a>
                   </div>
                   <div class="form-group" id="reservista1" style="display: none">
                     <label class="col-md-3 control-label">Número do certificado reservista</label>
@@ -401,7 +402,7 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
                     </div>
                   </div>
                 </form>
-                <iframe name="frame"></iframe>
+                <iframe name="frame" title="Frame auxiliar de envio do formulário"></iframe>
                 <!-- end: page -->
     </section>
   </div>
@@ -924,7 +925,7 @@ $(document).ready(function() {
 </script>
 
   <div align="right">
-    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;"></iframe>
+    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
   </div>
 </body>
 

--- a/web/html/funcionario/cadastro_funcionario_pessoa_existente.php
+++ b/web/html/funcionario/cadastro_funcionario_pessoa_existente.php
@@ -76,14 +76,14 @@ try {
 }
 ?>
 <!DOCTYPE html>
-<html class="fixed">
+<html class="fixed" lang="pt-br">
 
 <head>
   <!-- Basic -->
   <meta charset="UTF-8">
   <title>Cadastro de Funcionário</title>
   <!-- Mobile Metas -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <!-- Web Fonts  -->
   <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800|Shadows+Into+Light" rel="stylesheet" type="text/css">
@@ -173,7 +173,7 @@ try {
             <li><span>Cadastros</span></li>
             <li><span>Funcionário</span></li>
           </ol>
-          <a class="sidebar-right-toggle"><i class="fa fa-chevron-left"></i></a>
+          <a class="sidebar-right-toggle" aria-label="Alternar painel lateral"><i class="fa fa-chevron-left"></i></a>
         </div>
       </header>
 
@@ -195,22 +195,22 @@ try {
                 <h4 class="mb-xlg">Informações Pessoais</h4>
                 <h5 class="obrig">Campos Obrigatórios(*)</h5>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileFirstName">Nome<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="nome">Nome<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="text" class="form-control" name="nome" id="nome" onkeypress="return Onlychars(event)">
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label">Sobrenome<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="sobrenome">Sobrenome<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="text" class="form-control" name="sobrenome" id="sobrenome" onkeypress="return Onlychars(event)">
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileLastName">Sexo<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label">Sexo<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
-                    <label><input type="radio" name="gender" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()"><i class="fa fa-male" style="font-size: 20px;"></i></label>
-                    <label><input type="radio" name="gender" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()"><i class="fa fa-female" style="font-size: 20px;"></i> </label>
+                    <label><input type="radio" name="gender" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()" aria-label="Masculino"><i class="fa fa-male" style="font-size: 20px;"></i></label>
+                    <label><input type="radio" name="gender" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()" aria-label="Feminino"><i class="fa fa-female" style="font-size: 20px;"></i> </label>
                   </div>
                 </div>
                 <div class="form-group">
@@ -220,7 +220,7 @@ try {
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Nascimento<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="nascimento">Nascimento<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="date" placeholder="dd/mm/aaaa" maxlength="10" class="form-control" name="nascimento" id="nascimento" max=<?php echo date('Y-m-d'); ?>>
                   </div>
@@ -237,7 +237,7 @@ try {
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Número do RG<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="rg">Número do RG<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="text" class="form-control<?= isset($fieldErrors['rg']) ? ' is-invalid' : '' ?>" name="rg" id="rg" onkeypress="return Onlynumbers(event)" placeholder="Ex: 22.222.222-2" onkeyup="mascara('##.###.###-#',this,event)" required value="<?= htmlspecialchars($oldInput['rg'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                     <p id="error_rg" class="help-block text-danger" style="display: <?= isset($fieldErrors['rg']) ? 'block' : 'none' ?>;">
@@ -246,7 +246,7 @@ try {
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Órgão Emissor<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="orgao_emissor">Órgão Emissor<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="text" class="form-control<?= isset($fieldErrors['orgao_emissor']) ? ' is-invalid' : '' ?>" name="orgao_emissor" id="orgao_emissor" onkeypress="return Onlychars(event)" required value="<?= htmlspecialchars($oldInput['orgao_emissor'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                     <p id="error_orgao_emissor" class="help-block text-danger" style="display: <?= isset($fieldErrors['orgao_emissor']) ? 'block' : 'none' ?>;">
@@ -255,7 +255,7 @@ try {
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Data de expedição<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="data_expedicao">Data de expedição<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="date" class="form-control<?= isset($fieldErrors['data_expedicao']) ? ' is-invalid' : '' ?>" maxlength="10" placeholder="dd/mm/aaaa" name="data_expedicao" id="data_expedicao" max=<?php echo date('Y-m-d'); ?> required value="<?= htmlspecialchars($oldInput['data_expedicao'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                     <p id="error_data_expedicao" class="help-block text-danger" style="display: <?= isset($fieldErrors['data_expedicao']) ? 'block' : 'none' ?>;">
@@ -270,7 +270,7 @@ try {
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="profileCompany">Data de Admissão<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="data_admissao">Data de Admissão<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <input type="date" placeholder="dd/mm/aaaa" maxlength="10" class="form-control<?= isset($fieldErrors['data_admissao']) ? ' is-invalid' : '' ?>" name="data_admissao" id="data_admissao" max=<?php echo date('Y-m-d'); ?> required value="<?= htmlspecialchars($oldInput['data_admissao'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                     <p id="error_data_admissao" class="help-block text-danger" style="display: <?= isset($fieldErrors['data_admissao']) ? 'block' : 'none' ?>;">
@@ -279,8 +279,8 @@ try {
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="inputSuccess">Situação<sup class="obrig">*</sup></label>
-                  <a onclick="adicionar_situacao()"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                  <label class="col-md-3 control-label" for="situacao">Situação<sup class="obrig">*</sup></label>
+                  <a onclick="adicionar_situacao()" aria-label="Adicionar situação"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                   <div class="col-md-6">
                     <select class="form-control input-lg mb-md" name="situacao" id="situacao" required>
                       <option selected disabled>Selecionar</option>
@@ -294,8 +294,8 @@ try {
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label" for="inputSuccess">Cargo<sup class="obrig">*</sup></label>
-                  <a onclick="adicionar_cargo()"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                  <label class="col-md-3 control-label" for="cargo">Cargo<sup class="obrig">*</sup></label>
+                  <a onclick="adicionar_cargo()" aria-label="Adicionar cargo"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                   <div class="col-md-6">
                     <select class="form-control input-lg mb-md" name="cargo" id="cargo" required>
                       <option selected disabled>Selecionar</option>
@@ -310,7 +310,7 @@ try {
                 </div>
 
                 <div class="form-group">
-                  <label class="col-md-3 control-label">Escala<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="escala_input">Escala<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <select class="form-control input-lg mb-md" name="escala" id="escala_input" required>
                       <option selected disabled value="">Selecionar</option>
@@ -322,10 +322,10 @@ try {
                       ?>
                     </select>
                   </div>
-                  <a href="../quadro_horario/adicionar_escala.php"><i class="fas fa-plus w3-xlarge"></i></a>
+                  <a href="../quadro_horario/adicionar_escala.php" aria-label="Adicionar escala"><i class="fas fa-plus w3-xlarge"></i></a>
                 </div>
                 <div class="form-group">
-                  <label class="col-md-3 control-label">Tipo<sup class="obrig">*</sup></label>
+                  <label class="col-md-3 control-label" for="tipoCargaHoraria_input">Tipo<sup class="obrig">*</sup></label>
                   <div class="col-md-6">
                     <select class="form-control input-lg mb-md" name="tipoCargaHoraria" id="tipoCargaHoraria_input" required>
                       <option selected disabled value="">Selecionar</option>
@@ -337,18 +337,18 @@ try {
                       ?>
                     </select>
                   </div>
-                  <a href="../quadro_horario/adicionar_tipo_quadro_horario.php"><i class="fas fa-plus w3-xlarge"></i></a>
+                  <a href="../quadro_horario/adicionar_tipo_quadro_horario.php" aria-label="Adicionar tipo de carga horária"><i class="fas fa-plus w3-xlarge"></i></a>
                 </div>
                 <div class="form-group" id="reservista1" style="display: none">
-                  <label class="col-md-3 control-label">Número do certificado reservista</label>
+                  <label class="col-md-3 control-label" for="certificado_reservista_numero">Número do certificado reservista</label>
                   <div class="col-md-6">
-                    <input type="text" name="certificado_reservista_numero" class="form-control num_reservista">
+                    <input type="text" name="certificado_reservista_numero" id="certificado_reservista_numero" class="form-control num_reservista">
                   </div>
                 </div>
                 <div class="form-group" id="reservista2" style="display: none">
-                  <label class="col-md-3 control-label">Série do certificado reservista</label>
+                  <label class="col-md-3 control-label" for="certificado_reservista_serie">Série do certificado reservista</label>
                   <div class="col-md-6">
-                    <input type="text" name="certificado_reservista_serie" class="form-control serie_reservista">
+                    <input type="text" name="certificado_reservista_serie" id="certificado_reservista_serie" class="form-control serie_reservista">
                   </div>
                 </div>
 
@@ -680,7 +680,7 @@ try {
   <script src="../../assets/vendor/jquery-placeholder/jquery.placeholder.js"></script>
 
   <div align="right">
-    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;"></iframe>
+    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
   </div>
 </body>
 

--- a/web/html/funcionario/informacao_funcionario.php
+++ b/web/html/funcionario/informacao_funcionario.php
@@ -38,7 +38,7 @@ require_once ROOT . "/controle/FuncionarioControle.php";
 require_once "../personalizacao_display.php";
 ?>
 <!doctype html>
-<html class="fixed">
+<html class="fixed" lang="pt-br">
 
 <head>
 	<!-- Basic -->
@@ -47,7 +47,7 @@ require_once "../personalizacao_display.php";
 	<title>Informações</title>
 
 	<!-- Mobile Metas -->
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 	<!-- Vendor CSS -->
 	<link rel="stylesheet" href="../../assets/vendor/bootstrap/css/bootstrap.css" />
@@ -159,14 +159,14 @@ require_once "../personalizacao_display.php";
 							</li>
 							<li><span>Informações Funcionário</span></li>
 						</ol>
-						<a class="sidebar-right-toggle"><i class="fa fa-chevron-left"></i></a>
+						<a class="sidebar-right-toggle" aria-label="Alternar painel lateral"><i class="fa fa-chevron-left"></i></a>
 					</div>
 				</header>
 				<!-- start: page -->
 				<section class="panel">
 					<header class="panel-heading">
 						<div class="panel-actions">
-							<a href="#" class="fa fa-caret-down"></a>
+							<a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
 						</div>
 						<h2 class="panel-title">Funcionário</h2>
 					</header>
@@ -179,11 +179,11 @@ require_once "../personalizacao_display.php";
 					<section class="panel">
 						<header class="panel-heading">
 							<div class="panel-actions">
-								<a href="#" class="fa fa-caret-down"></a>
+								<a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
 							</div>
 							<h2 class="panel-title">Selecione a situação:</h2><br>
 							<form method="GET" action="#" id="select_situacao" name="select_situacao">
-								<select name="select_situacao" id="situacao">
+								<select name="select_situacao" id="situacao" aria-label="Selecione a situação">
 									<?php
 									foreach ($situacoes as $situacao) { ?>
 										<option value="<?php echo $situacao['id_situacao']; ?>">
@@ -235,7 +235,7 @@ require_once "../personalizacao_display.php";
 					<script src="../../assets/javascripts/tables/examples.datatables.tabletools.js"></script>
 
 					<div align="right">
-						<iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;"></iframe>
+						<iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
 					</div>
 </body>
 

--- a/web/html/funcionario/pre_cadastro_funcionario.php
+++ b/web/html/funcionario/pre_cadastro_funcionario.php
@@ -31,7 +31,7 @@ require_once ROOT . "/html/geral/msg.php";
 
 <!DOCTYPE html>
 
-<html class="fixed">
+<html class="fixed" lang="pt-br">
 
 <head>
     <!-- Basic -->
@@ -40,7 +40,7 @@ require_once ROOT . "/html/geral/msg.php";
     <title>Cadastro de Funcionário</title>
 
     <!-- Mobile Metas -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800|Shadows+Into+Light" rel="stylesheet" type="text/css">
     <!-- Vendor CSS -->
     <link rel="stylesheet" href="<?php echo WWW; ?>assets/vendor/bootstrap/css/bootstrap.css" />
@@ -202,7 +202,7 @@ require_once ROOT . "/html/geral/msg.php";
                             </li>
                             <li><span>Digite seu CPF</span></li>
                         </ol>
-                        <a class="sidebar-right-toggle"><i class="fa fa-chevron-left"></i></a>
+                        <a class="sidebar-right-toggle" aria-label="Alternar painel lateral"><i class="fa fa-chevron-left"></i></a>
                     </div>
                 </header>
 
@@ -229,7 +229,7 @@ require_once ROOT . "/html/geral/msg.php";
                     <div class="panel-body">
 
                         <form method="GET" action="../../controle/control.php" id="formCpf">
-                            <input type="text" class="form-control" id="cpf" name="cpf" placeholder="Ex: 222.222.222-22" maxlength="14" onkeypress="return Onlynumbers(event)" onkeyup="mascara('###.###.###-##',this,event)" required>
+                            <input type="text" class="form-control" id="cpf" name="cpf" placeholder="Ex: 222.222.222-22" maxlength="14" onkeypress="return Onlynumbers(event)" onkeyup="mascara('###.###.###-##',this,event)" aria-label="CPF" required>
                             <p id="cpfInvalido" style="display: none; color: #b30000">CPF INVÁLIDO!</p>
                             <br>
                             <input type="hidden" name="nomeClasse" value="FuncionarioControle"> 
@@ -290,7 +290,7 @@ require_once ROOT . "/html/geral/msg.php";
     <script src="<?php echo WWW; ?>assets/javascripts/tables/examples.datatables.tabletools.js"></script>
 
     <div align="right">
-        <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;"></iframe>
+        <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
     </div>
 </body>
 

--- a/web/html/funcionario/profile_dependente.php
+++ b/web/html/funcionario/profile_dependente.php
@@ -51,7 +51,7 @@ try {
 
 ?>
 <!doctype html>
-<html class="fixed">
+<html class="fixed" lang="pt-br">
 
 <head>
     <!-- Basic -->
@@ -61,7 +61,7 @@ try {
     <meta name="description" content="Porto Admin - Responsive HTML5 Template">
     <meta name="author" content="okler.net">
     <!-- Mobile Metas -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <!-- Web Fonts  -->
     <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800|Shadows+Into+Light" rel="stylesheet" type="text/css">
     <link rel="icon" href="<?php display_campo("Logo", 'file'); ?>" type="image/x-icon" id="logo-icon">
@@ -399,8 +399,8 @@ try {
                         .append($("<td>").text(item.descricao))
                         .append($("<td>").text(item.data))
                         .append($("<td style='display: flex; justify-content: space-evenly;'>")
-                            .append($("<a href='dependente_docdependente.php?action=download&id_doc=" + item.id_doc + "' title='Visualizar ou Baixar'><button class='btn btn-primary'><i class='fas fa-download'></i></button></a>"))
-                            .append($("<a href='#' onclick='excluir_docdependente(" + item.id_doc + ")' title='Excluir'><button class='btn btn-danger'><i class='fas fa-trash-alt'></i></button></a>"))
+                            .append($("<a href='dependente_docdependente.php?action=download&id_doc=" + item.id_doc + "' title='Visualizar ou Baixar'><button class='btn btn-primary' title='Visualizar ou Baixar'><i class='fas fa-download'></i></button></a>"))
+                            .append($("<a href='#' onclick='excluir_docdependente(" + item.id_doc + ")' title='Excluir'><button class='btn btn-danger' title='Excluir'><i class='fas fa-trash-alt'></i></button></a>"))
                         )
                     )
             });
@@ -491,7 +491,7 @@ try {
                             <li><span>Páginas</span></li>
                             <li><span>Dependente</span></li>
                         </ol>
-                        <a class="sidebar-right-toggle"><i class="fa fa-chevron-left"></i></a>
+                        <a class="sidebar-right-toggle" aria-label="Alternar painel lateral"><i class="fa fa-chevron-left"></i></a>
                     </div>
                 </header>
                 <!-- start: page -->
@@ -539,10 +539,10 @@ try {
                                                 </div>
                                             </div>
                                             <div class="form-group">
-                                                <label class="col-md-3 control-label" for="profileLastName">Sexo</label>
+                                                <label class="col-md-3 control-label">Sexo</label>
                                                 <div class="col-md-8">
-                                                    <label><input type="radio" name="sexo" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" disabled><i class="fa fa-male" style="font-size: 20px;"></i></label>
-                                                    <label><input type="radio" name="sexo" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" disabled><i class="fa fa-female" style="font-size: 20px;"></i></label>
+                                                    <label><input type="radio" name="sexo" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" disabled aria-label="Masculino"><i class="fa fa-male" style="font-size: 20px;"></i></label>
+                                                    <label><input type="radio" name="sexo" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" disabled aria-label="Feminino"><i class="fa fa-female" style="font-size: 20px;"></i></label>
                                                 </div>
                                             </div>
                                             <div class="form-group">
@@ -610,7 +610,7 @@ try {
                                     <section class="panel">
                                         <header class="panel-heading">
                                             <div class="panel-actions">
-                                                <a href="#" class="fa fa-caret-down"></a>
+                                                <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                                             </div>
                                             <h2 class="panel-title">Arquivos</h2>
                                         </header>
@@ -643,7 +643,7 @@ try {
                                                         <form action='docdependente_upload.php' method='post' enctype='multipart/form-data' id='funcionarioDocForm'>
                                                             <div class="modal-body" style="padding: 15px 40px">
                                                                 <div class="form-group" style="display: grid;">
-                                                                    <label class="my-1 mr-2" for="id_docdependente">Tipo de Documento</label><br>
+                                                                    <label class="my-1 mr-2" for="tipoDocumento">Tipo de Documento</label><br>
                                                                     <div style="display: flex;">
                                                                         <select name="id_docdependente" class="custom-select my-1 mr-sm-2" id="tipoDocumento" required>
                                                                             <option selected disabled>Selecionar...</option>
@@ -653,7 +653,7 @@ try {
                                                                             }
                                                                             ?>
                                                                         </select>
-                                                                        <a onclick="adicionarDocDependente()" style="margin: 0 20px;"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                                                                        <a onclick="adicionarDocDependente()" style="margin: 0 20px;" aria-label="Adicionar documento do dependente"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                                                                     </div>
                                                                 </div>
                                                                 <div class="form-group">
@@ -679,25 +679,25 @@ try {
                                     <form method='POST' id="formDocumentacao">
                                         <fieldset id="formDocumentacao">
                                             <div class="form-group">
-                                                <label class="col-md-3 control-label" for="profileCompany">Número do RG</label>
+                                                <label class="col-md-3 control-label" for="rg">Número do RG</label>
                                                 <div class="col-md-8">
                                                     <input type="text" class="form-control" name="rg" id="rg" onkeypress="return Onlynumbers(event)" placeholder="Ex: 22.222.222-2" onkeydown="mascara('##.###.###-#',this,event)">
                                                 </div>
                                             </div>
                                             <div class="form-group">
-                                                <label class="col-md-3 control-label" for="profileCompany">Órgão Emissor</label>
+                                                <label class="col-md-3 control-label" for="orgao_emissor">Órgão Emissor</label>
                                                 <div class="col-md-8">
                                                     <input type="text" class="form-control" name="orgao_emissor" id="orgao_emissor" onkeypress="return Onlychars(event)">
                                                 </div>
                                             </div>
                                             <div class="form-group">
-                                                <label class="col-md-3 control-label" for="profileCompany">Data de expedição</label>
+                                                <label class="col-md-3 control-label" for="data_expedicao">Data de expedição</label>
                                                 <div class="col-md-8">
                                                     <input type="date" class="form-control" maxlength="10" placeholder="dd/mm/aaaa" name="data_expedicao" id="data_expedicao" max="<?php echo date('Y-m-d'); ?>" onchange="validarDatasNascimentoExpedicao()">
                                                 </div>
                                             </div>
                                             <div class="form-group">
-                                                <label class="col-md-3 control-label" for="profileCompany">Número do CPF</label>
+                                                <label class="col-md-3 control-label" for="cpf">Número do CPF</label>
                                                 <div class="col-md-8">
                                                     <input type="text" class="form-control" id="cpf" name="cpf" placeholder="Ex: 222.222.222-22" maxlength="14" onblur="validarCPF(this.value)" onkeypress="return Onlynumbers(event)" onkeydown="mascara('###.###.###-##',this,event)" required>
                                                 </div>
@@ -752,7 +752,7 @@ try {
                                                 </div>
                                             </div>
                                             <div class="form-group">
-                                                <label class="col-md-3 control-label" for="profileCompany">Número residencial</label>
+                                                <label class="col-md-3 control-label" for="numero_residencia">Número residencial</label>
                                                 <div class="col-md-4">
                                                     <input type="number" min="0" oninput="this.value = Math.abs(this.value)" class="form-control" name="numero_residencia" id="numero_residencia">
                                                 </div>
@@ -763,7 +763,7 @@ try {
                                                 </div>
                                             </div>
                                             <div class="form-group">
-                                                <label class="col-md-3 control-label" for="profileCompany">Complemento</label>
+                                                <label class="col-md-3 control-label" for="complemento">Complemento</label>
                                                 <div class="col-md-8">
                                                     <input type="text" class="form-control" name="complemento" id="complemento">
                                                 </div>
@@ -818,7 +818,7 @@ try {
         });
     </script>
     <div align="right">
-        <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;"></iframe>
+        <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
     </div>
 </body>
 

--- a/web/html/funcionario/profile_funcionario.php
+++ b/web/html/funcionario/profile_funcionario.php
@@ -148,7 +148,7 @@ try {
 }
 ?>
 <!doctype html>
-<html class="fixed">
+<html class="fixed" lang="pt-br">
 
 <head>
   <!-- Basic -->
@@ -158,7 +158,7 @@ try {
   <meta name="description" content="Porto Admin - Responsive HTML5 Template">
   <meta name="author" content="okler.net">
   <!-- Mobile Metas -->
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- Web Fonts  -->
   <link href="http://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800|Shadows+Into+Light" rel="stylesheet" type="text/css">
   <link rel="icon" href="<?php display_campo("Logo", 'file'); ?>" type="image/x-icon" id="logo-icon">
@@ -505,8 +505,8 @@ try {
             .append($("<td>").text(item.nome_docfuncional))
             .append($("<td>").text(item.data))
             .append($("<td style='display: flex; justify-content: space-evenly;'>")
-              .append($("<a href='documento_download.php?id_doc=" + item.id_fundocs + "' title='Visualizar ou Baixar'><button class='btn btn-primary'><i class='fas fa-download'></i></button></a>"))
-              .append($("<a onclick='removerFuncionarioDocs(" + item.id_fundocs + ")' href='#' title='Excluir'><button class='btn btn-danger'><i class='fas fa-trash-alt'></i></button></a>"))
+              .append($("<a href='documento_download.php?id_doc=" + item.id_fundocs + "' title='Visualizar ou Baixar'><button class='btn btn-primary' title='Visualizar ou Baixar'><i class='fas fa-download'></i></button></a>"))
+              .append($("<a onclick='removerFuncionarioDocs(" + item.id_fundocs + ")' href='#' title='Excluir'><button class='btn btn-danger' title='Excluir'><i class='fas fa-trash-alt'></i></button></a>"))
             )
           )
       });
@@ -520,8 +520,8 @@ try {
             .append($("<td>").text(item.nome_docfuncional))
             .append($("<td>").text(item.data))
             .append($("<td style='display: flex; justify-content: space-evenly;'>")
-              .append($("<a href='documento_download.php?id_doc=" + item.id_fundocs + "' title='Visualizar ou Baixar'><button class='btn btn-primary'><i class='fas fa-download'></i></button></a>"))
-              .append($("<a onclick='removerFuncionarioDocs(" + item.id_fundocs + ")' href='#' title='Excluir'><button class='btn btn-danger'><i class='fas fa-trash-alt'></i></button></a>"))
+              .append($("<a href='documento_download.php?id_doc=" + item.id_fundocs + "' title='Visualizar ou Baixar'><button class='btn btn-primary' title='Visualizar ou Baixar'><i class='fas fa-download'></i></button></a>"))
+              .append($("<a onclick='removerFuncionarioDocs(" + item.id_fundocs + ")' href='#' title='Excluir'><button class='btn btn-danger' title='Excluir'><i class='fas fa-trash-alt'></i></button></a>"))
             )
           )
       });
@@ -543,8 +543,8 @@ try {
             .append($("<td>").text(dependente.cpf))
             .append($("<td>").text(dependente.parentesco))
             .append($("<td style='display: flex; justify-content: space-evenly;'>")
-              .append($("<a href='profile_dependente.php?id_dependente=" + dependente.id_dependente + "' title='Editar'><button class='btn btn-primary'><i class='fas fa-user-edit'></i></button></a>"))
-              .append($("<button class='btn btn-danger' onclick='removerDependente(" + dependente.id_dependente + ")'><i class='fas fa-trash-alt'></i></button>"))
+              .append($("<a href='profile_dependente.php?id_dependente=" + dependente.id_dependente + "' title='Editar'><button class='btn btn-primary' title='Editar'><i class='fas fa-user-edit'></i></button></a>"))
+              .append($("<button class='btn btn-danger' title='Excluir' onclick='removerDependente(" + dependente.id_dependente + ")'><i class='fas fa-trash-alt'></i></button>"))
             )
           )
       });
@@ -741,7 +741,7 @@ try {
               <li><span>Páginas</span></li>
               <li><span>Perfil</span></li>
             </ol>
-            <a class="sidebar-right-toggle"><i class="fa fa-chevron-left"></i></a>
+            <a class="sidebar-right-toggle" aria-label="Alternar painel lateral"><i class="fa fa-chevron-left"></i></a>
           </div>
         </header>
         <!-- start: page -->
@@ -782,7 +782,7 @@ try {
                   }
                   echo "<img src='$foto' style='margin-bottom: 15px;' id='imagem' class='rounded img-responsive' alt='John Doe'>";
                   ?>
-                  <button class="btn btn-info btn-lg" data-toggle="modal" data-target="#myModal"><i class="fa fa-camera-retro"></i></button>
+                  <button class="btn btn-info btn-lg" data-toggle="modal" data-target="#myModal" aria-label="Alterar foto de perfil"><i class="fa fa-camera-retro"></i></button>
 
                   <div class="container">
                     <div class="modal fade" id="myModal" role="dialog">
@@ -799,7 +799,7 @@ try {
                               <input type="hidden" name="metodo" value="alterarImagem">
                               <?= Csrf::inputField() ?>
                               <div class="form-group">
-                                <label class="col-md-4 control-label" for="imgperfil">Carregue nova imagem de perfil:</label>
+                                <label class="col-md-4 control-label" for="imgform">Carregue nova imagem de perfil:</label>
                                 <div class="col-md-8">
                                   <input type="file" name="imgperfil" size="60" id="imgform" class="form-control">
                                 </div>
@@ -864,22 +864,22 @@ try {
                     <h4 class="mb-xlg">Informações Pessoais</h4>
                     <fieldset>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="profileFirstName">Nome</label>
+                        <label class="col-md-3 control-label" for="nomeForm">Nome</label>
                         <div class="col-md-8">
                           <input type="text" class="form-control" name="nome" id="nomeForm" onkeypress="return Onlychars(event)">
                         </div>
                       </div>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="profileFirstName">Sobrenome</label>
+                        <label class="col-md-3 control-label" for="sobrenomeForm">Sobrenome</label>
                         <div class="col-md-8">
                           <input type="text" class="form-control" name="sobrenome" id="sobrenomeForm" onkeypress="return Onlychars(event)">
                         </div>
                       </div>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="profileLastName">Sexo</label>
+                        <label class="col-md-3 control-label">Sexo</label>
                         <div class="col-md-8">
-                          <label><input type="radio" name="gender" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()"> <i class="fa fa-male" style="font-size: 20px;"></i></label>
-                          <label><input type="radio" name="gender" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()"> <i class="fa fa-female" style="font-size: 20px;"></i> </label>
+                          <label><input type="radio" name="gender" id="radioM" value="m" style="margin-top: 10px; margin-left: 15px;" onclick="return exibir_reservista()" aria-label="Masculino"> <i class="fa fa-male" style="font-size: 20px;"></i></label>
+                          <label><input type="radio" name="gender" id="radioF" value="f" style="margin-top: 10px; margin-left: 15px;" onclick="return esconder_reservista()" aria-label="Feminino"> <i class="fa fa-female" style="font-size: 20px;"></i> </label>
                         </div>
                       </div>
                       <div class="form-group">
@@ -889,13 +889,13 @@ try {
                         </div>
                       </div>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="profileCompany">Telefone</label>
+                        <label class="col-md-3 control-label" for="telefone">Telefone</label>
                         <div class="col-md-8">
                           <input type="text" class="form-control" maxlength="14" minlength="14" name="telefone" id="telefone" placeholder="Ex: (22)99999-9999" onkeypress="return Onlynumbers(event)" onkeyup="mascara('(##)#####-####',this,event)" required>
                         </div>
                       </div>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="profileCompany">Nascimento</label>
+                        <label class="col-md-3 control-label" for="nascimento">Nascimento</label>
                         <div class="col-md-8">
                           <input type="date"
                             placeholder="dd/mm/aaaa"
@@ -915,19 +915,19 @@ try {
                         </div>
                       </div>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="profileFirstName">Nome do pai</label>
+                        <label class="col-md-3 control-label" for="pai">Nome do pai</label>
                         <div class="col-md-8">
                           <input type="text" class="form-control" name="nome_pai" id="pai" onkeypress="return Onlychars(event)">
                         </div>
                       </div>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="profileFirstName">Nome da mãe</label>
+                        <label class="col-md-3 control-label" for="mae">Nome da mãe</label>
                         <div class="col-md-8">
                           <input type="text" class="form-control" name="nome_mae" id="mae" onkeypress="return Onlychars(event)">
                         </div>
                       </div>
                       <div class="form-group">
-                        <label class="col-md-3 control-label" for="inputSuccess">Tipo sanguíneo</label>
+                        <label class="col-md-3 control-label" for="sangue">Tipo sanguíneo</label>
                         <div class="col-md-6">
                           <select class="form-control input-lg mb-md" name="sangue" id="sangue">
                             <option selected disabled>Selecionar</option>
@@ -1037,7 +1037,7 @@ try {
                   <section class="panel">
                     <header class="panel-heading">
                       <div class="panel-actions">
-                        <a href="#" class="fa fa-caret-down"></a>
+                        <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                       </div>
                       <h2 class="panel-title">Remuneração</h2>
                     </header>
@@ -1079,7 +1079,7 @@ try {
                                     }
                                     ?>
                                   </select>
-                                  <a onclick="adicionarTipoRemuneracao()" style="margin: 0 20px;" id="btn_adicionar_tipo_remuneracao"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                                  <a onclick="adicionarTipoRemuneracao()" style="margin: 0 20px;" id="btn_adicionar_tipo_remuneracao" aria-label="Adicionar tipo de remuneração"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                                 </div>
                               </div>
                               <div class="form-group">
@@ -1131,7 +1131,7 @@ try {
                   <section class="panel">
                     <header class="panel-heading">
                       <div class="panel-actions">
-                        <a href="#" class="fa fa-caret-down"></a>
+                        <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                       </div>
                       <h2 class="panel-title">Outros</h2>
                     </header>
@@ -1164,7 +1164,7 @@ try {
 
                         <!-- Campo Estado CTPS -->
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="uf">Estado CTPS</label>
+                          <label class="col-md-3 control-label" for="uf_ctps">Estado CTPS</label>
                           <div class="col-md-6">
                             <input type="text" name="uf_ctps" size="60" class="form-control" id="uf_ctps" value="<?= htmlspecialchars($oldInput['uf_ctps'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                           </div>
@@ -1231,7 +1231,7 @@ try {
                         </div>
 
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="profileCompany">Data de Admissão<sup class="obrig">*</sup></label>
+                          <label class="col-md-3 control-label" for="data_admissao">Data de Admissão<sup class="obrig">*</sup></label>
                           <div class="col-md-6">
                             <input type="date" placeholder="dd/mm/aaaa" maxlength="10" class="form-control<?= isset($fieldErrors['data_admissao']) ? ' is-invalid' : '' ?>" name="data_admissao" id="data_admissao" max="<?= date('Y-m-d') ?>" required value="<?= htmlspecialchars($oldInput['data_admissao'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                             <?php if (!empty($fieldErrors['data_admissao'])): ?>
@@ -1256,10 +1256,10 @@ try {
                               <div class="invalid-feedback d-block"><?= htmlspecialchars($fieldErrors['situacao'], ENT_QUOTES, 'UTF-8') ?></div>
                             <?php endif; ?>
                           </div>
-                          <a onclick="adicionar_situacao()"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                          <a onclick="adicionar_situacao()" aria-label="Adicionar situação"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label" style='text-align: right;  margin-top: 10px;' for="inputSuccess">Cargo<sup class="obrig">*</sup></label>
+                          <label class="col-md-3 control-label" style='text-align: right;  margin-top: 10px;' for="cargo">Cargo<sup class="obrig">*</sup></label>
                           <div class="col-md-6">
                             <select class="form-control input-lg mb-md<?= !empty($fieldErrors['cargo']) ? ' is-invalid' : '' ?>" name="cargo" id="cargo" required>
                               <option value="" selected disabled>Selecionar</option>
@@ -1278,7 +1278,7 @@ try {
                               <div class="invalid-feedback d-block"><?= htmlspecialchars($fieldErrors['cargo'], ENT_QUOTES, 'UTF-8') ?></div>
                             <?php endif; ?>
                           </div>
-                          <a onclick="adicionar_cargo()"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                          <a onclick="adicionar_cargo()" aria-label="Adicionar cargo"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                         </div>
                         <!-- Pegar id funcionário de variável sanitizada -->
                         <input type="hidden" name="id_funcionario" value=<?= $idFuncionario ?>>
@@ -1360,7 +1360,7 @@ try {
                                       }
                                       ?>
                                     </select>
-                                    <a onclick="adicionar_addInfoDescricao()"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw; margin-left: 10px;"></i></a>
+                                    <a onclick="adicionar_addInfoDescricao()" aria-label="Adicionar descrição"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw; margin-left: 10px;"></i></a>
                                   </div>
                                 </div>
                                 <div class="form-group">
@@ -1481,14 +1481,14 @@ try {
                   <section class="panel">
                     <header class="panel-heading">
                       <div class="panel-actions">
-                        <a href="#" class="fa fa-caret-down"></a>
+                        <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                       </div>
                       <h2 class="panel-title">Carga Horária</h2>
                     </header>
                     <div class="panel-body">
                       <form class="form-horizontal" method="post" action="../../controle/control.php" id="formAlterarCargaHoraria">
                         <div class="form-group">
-                          <label class="col-md-3 control-label">Escala</label>
+                          <label class="col-md-3 control-label" for="escala_input">Escala</label>
                           <div class="col-md-6">
                             <select class="form-control input-lg mb-md" name="escala" id="escala_input">
                               <option id="escala_default" selected disabled value="">Selecionar</option>
@@ -1503,7 +1503,7 @@ try {
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label">Tipo</label>
+                          <label class="col-md-3 control-label" for="tipoCargaHoraria_input">Tipo</label>
                           <div class="col-md-6">
                             <select class="form-control input-lg mb-md" name="tipoCargaHoraria" id="tipoCargaHoraria_input">
                               <option selected disabled value="">Selecionar</option>
@@ -1547,25 +1547,25 @@ try {
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label">Primeira entrada</label>
+                          <label class="col-md-3 control-label" for="entrada1_input">Primeira entrada</label>
                           <div class="col-md-3">
                             <input type="time" placeholder="07:25" class="form-control" name="entrada1" id="entrada1_input">
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label">Primeira saída</label>
+                          <label class="col-md-3 control-label" for="saida1_input">Primeira saída</label>
                           <div class="col-md-3">
                             <input type="time" placeholder="07:25" class="form-control" name="saida1" id="saida1_input">
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label">Segunda entrada</label>
+                          <label class="col-md-3 control-label" for="entrada2_input">Segunda entrada</label>
                           <div class="col-md-3">
                             <input type="time" placeholder="07:25" class="form-control" name="entrada2" id="entrada2_input">
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label">Segunda saída</label>
+                          <label class="col-md-3 control-label" for="saida2_input">Segunda saída</label>
                           <div class="col-md-3">
                             <input type="time" placeholder="07:25" class="form-control" name="saida2" id="saida2_input">
                           </div>
@@ -1672,7 +1672,7 @@ try {
                   <section class="panel">
                     <header class="panel-heading">
                       <div class="panel-actions">
-                        <a href="#" class="fa fa-caret-down"></a>
+                        <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                       </div>
                       <h2 class="panel-title">Documentos</h2>
                     </header>
@@ -1684,25 +1684,25 @@ try {
                         <input type="hidden" name="metodo" value="alterarDocumentacao">
                         <?= Csrf::inputField() ?>
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="profileCompany">Número do RG</label>
+                          <label class="col-md-3 control-label" for="rg">Número do RG</label>
                           <div class="col-md-6">
                             <input type="text" class="form-control" name="rg" id="rg" onkeypress="return Onlynumbers(event)" placeholder="Ex: 22.222.222-2" onkeyup="mascara('##.###.###-#',this,event)" required>
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="profileCompany">Órgão Emissor</label>
+                          <label class="col-md-3 control-label" for="orgao_emissor">Órgão Emissor</label>
                           <div class="col-md-6">
                             <input type="text" class="form-control" name="orgao_emissor" id="orgao_emissor" onkeypress="return Onlychars(event)" required>
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="profileCompany">Data de expedição</label>
+                          <label class="col-md-3 control-label" for="data_expedicao">Data de expedição</label>
                           <div class="col-md-6">
                             <input type="date" class="form-control" maxlength="10" placeholder="dd/mm/aaaa" name="data_expedicao" id="data_expedicao" max=<?php echo date('Y-m-d'); ?> required>
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="profileCompany">Número do CPF</label>
+                          <label class="col-md-3 control-label" for="cpf">Número do CPF</label>
                           <div class="col-md-6">
                             <input type="text" class="form-control" id="cpf" name="cpf" placeholder="Ex: 222.222.222-22" maxlength="14" onblur="validarCPF(this.value, 'enviarEditar')" onkeypress="return Onlynumbers(event)" onkeyup="mascara('###.###.###-##',this,event)" required>
                           </div>
@@ -1761,7 +1761,7 @@ try {
                   <section class="panel">
                     <header class="panel-heading">
                       <div class="panel-actions">
-                        <a href="#" class="fa fa-caret-down"></a>
+                        <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                       </div>
                       <h2 class="panel-title">Arquivos</h2>
                     </header>
@@ -1859,7 +1859,7 @@ try {
                   <section class="panel">
                     <header class="panel-heading">
                       <div class="panel-actions">
-                        <a href="#" class="fa fa-caret-down"></a>
+                        <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                       </div>
                       <h2 class="panel-title">Dependentes</h2>
                     </header>
@@ -1919,7 +1919,7 @@ try {
                                       }
                                       ?>
                                     </select>
-                                    <a onclick="adicionarParentesco()" style="margin: 0 20px;"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
+                                    <a onclick="adicionarParentesco()" style="margin: 0 20px;" aria-label="Adicionar parentesco"><i class="fas fa-plus w3-xlarge" style="margin-top: 0.75vw"></i></a>
                                   </div>
                                 </div>
                                 <input type="hidden" name="id_funcionario" value=<?= $idFuncionario ?> readonly>
@@ -1944,7 +1944,7 @@ try {
                   <section class="panel">
                     <header class="panel-heading">
                       <div class="panel-actions">
-                        <a href="#" class="fa fa-caret-down"></a>
+                        <a href="#" class="fa fa-caret-down" aria-label="Recolher ou expandir seção"></a>
                       </div>
                       <h2 class="panel-title">Endereço</h2>
                     </header>
@@ -1996,7 +1996,7 @@ try {
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="profileCompany">Número residencial</label>
+                          <label class="col-md-3 control-label" for="numero_residencia">Número residencial</label>
                           <div class="col-md-4">
                             <input type="number" min="0" oninput="this.value = Math.abs(this.value)" class="form-control" name="numero_residencia" id="numero_residencia">
                           </div>
@@ -2007,7 +2007,7 @@ try {
                           </div>
                         </div>
                         <div class="form-group">
-                          <label class="col-md-3 control-label" for="profileCompany">Complemento</label>
+                          <label class="col-md-3 control-label" for="complemento">Complemento</label>
                           <div class="col-md-8">
                             <input type="text" class="form-control" name="complemento" id="complemento">
                           </div>
@@ -2661,7 +2661,7 @@ try {
     <?php endif; ?>
   </script>
   <div align="right">
-    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;"></iframe>
+    <iframe src="https://www.wegia.org/software/footer/pessoa.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
   </div>
 </body>
 

--- a/web/index.php
+++ b/web/index.php
@@ -11,13 +11,11 @@ session_destroy();
 require_once "html/personalizacao_display.php";
 ?>
 <!doctype html>
-<html>
+<html lang="pt-br">
 <head>
 	<title><?php display_campo("Titulo", "str"); ?> - <?php display_campo("Subtitulo", "str"); ?></title>
 	<meta charset="UTF-8" />
 	<link rel="icon" href="<?php display_campo("Logo", "file"); ?>" type="image/x-icon">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 	<!-- Web Fonts  -->
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,800|Shadows+Into+Light" rel="stylesheet" type="text/css">
 	<!-- font inter -->
@@ -166,8 +164,8 @@ require_once "html/personalizacao_display.php";
 	<div class="container-fluid">
 		<div class="row cabecalho">
 			<div class="col-md-1 main-menu-logo">
-				<a class="logo pull-left">
-					<img src="<?php display_campo("Logo", "file"); ?>" height="50" />
+				<a class="logo pull-left" aria-label="Página inicial">
+					<img src="<?php display_campo("Logo", "file"); ?>" height="50" alt="Logo" />
 				</a>
 			</div>
 			<div class="col-md-4 descricao header-description">
@@ -180,7 +178,7 @@ require_once "html/personalizacao_display.php";
 				<form action="./html/login.php" method="POST" enctype="multipart/form-data" class="login">
 					<div class="form-group mb-lg form-group-login"><!--login-->
 						<div class="input-group input-group-icon"><!--icone-->
-							<input id="login" name="cpf" type="text" class="form-control input-lg" placeholder="Usuário" />
+							<input id="login" name="cpf" type="text" class="form-control input-lg" placeholder="Usuário" aria-label="Usuário" />
 							<span class="input-group-addon">
 								<span class="icon icon-lg">
 									<i class="fa fa-user"></i>
@@ -192,7 +190,7 @@ require_once "html/personalizacao_display.php";
 			<div class="col col-md-3 formulario pass-form">
 				<div class="form-group mb-lg form-group-login"><!--login-->
 					<div class="input-group input-group-icon"><!--icone-->
-						<input id="passwordInput" name="pwd" type="password" class="form-control input-lg form-input-pass" placeholder="Senha" />
+						<input id="passwordInput" name="pwd" type="password" class="form-control input-lg form-input-pass" placeholder="Senha" aria-label="Senha" />
 						<button type="button" id="togglePasswordVisibility" class="password-toggle-btn" aria-label="Mostrar senha" aria-pressed="false">
 							<i class="fa fa-eye"></i>
 						</button>
@@ -244,7 +242,7 @@ require_once "html/personalizacao_display.php";
 		</div>
 	</div>
 	<div align="right">
-		<iframe src="https://www.wegia.org/software/footer/index.html" width="200" height="60" style="border:none;"></iframe>
+		<iframe src="https://www.wegia.org/software/footer/index.html" width="200" height="60" style="border:none;" title="Rodapé"></iframe>
 	</div>
 	<div class="container-fluid">
 		<div class="footer row" style="background-color: black">
@@ -253,11 +251,11 @@ require_once "html/personalizacao_display.php";
 			</div>
 			<div class="col-md-4">
 				<div class="pull-right">
-					<a href="https://github.com/nilsonmori/WeGIA" target="_blank">
+					<a href="https://github.com/nilsonmori/WeGIA" target="_blank" aria-label="GitHub do WeGIA">
 						<span class="fa fa-github-square" style="color: white"></span></a>
-					<a href="https://www.facebook.com/wegiasoftware" target="_blank">
+					<a href="https://www.facebook.com/wegiasoftware" target="_blank" aria-label="Facebook do WeGIA">
 						<span class="fa fa-facebook-square" style="color: white"></span></a>
-					<a href="https://www.wegia.org" target="_blank">
+					<a href="https://www.wegia.org" target="_blank" aria-label="Site do WeGIA">
 						<span class="fa fa-globe" style="color: white"></span></a>
 				</div>
 			</div>


### PR DESCRIPTION
## Resumo

Corrige as violações WCAG (axe-core) reportadas nas issues com a label `wcag` para as páginas HTML do módulo Funcionário:

- `web/index.php`
- `web/html/funcionario/profile_funcionario.php`
- `web/html/funcionario/cadastro_funcionario.php`
- `web/html/funcionario/cadastro_funcionario_pessoa_existente.php`
- `web/html/funcionario/profile_dependente.php`
- `web/html/funcionario/cadastro_dependente_pessoa_nova.php`
- `web/html/funcionario/informacao_funcionario.php`
- `web/html/funcionario/pre_cadastro_funcionario.php`

## O que foi corrigido

- **html-has-lang**: adiciona `lang="pt-br"` em `<html>`
- **meta-viewport**: remove `maximum-scale=1.0, user-scalable=no`, que bloqueava zoom (falha WCAG 1.4.4)
- **frame-title**: adiciona `title` nos `<iframe>` de rodapé
- **image-alt**: adiciona `alt` no logo
- **label / select-name**: um bug sistemático de copy-paste fazia dezenas de `<label for="...">` apontarem para IDs que não existem em lugar nenhum da página (`profileFirstName`, `profileCompany`, `inputSuccess`, etc.), quebrando a associação com o campo. Corrigidos para apontar para o ID real do input/select correspondente.
- **link-name / button-name**: adiciona `aria-label`/`title` em links e botões só com ícone (recolher/expandir seção, adicionar item, excluir/baixar documento, alternar painel lateral, radios de gênero)
- Também corrigido um caso não coberto pelas issues originais: os campos de usuário/senha do login em `index.php` só tinham `placeholder`, sem nome acessível.

`php -l` limpo em todos os arquivos alterados.

## Sobre as demais issues WCAG

Dos 134 issues abertos com a label `wcag`, 39 (regras `document-title`/`html-has-lang` em endpoints como `documento_upload.php`, `dependente_cadastrar.php`, `remuneracao.php` etc.) eram falsos positivos do scanner — são handlers de backend que retornam JSON/redirecionam e nunca renderizam um documento HTML. Foram fechados no GitHub com comentário explicando o motivo. Os 95 restantes foram corrigidos neste PR e fechados referenciando o commit.

## Test plan

- [x] `php -l` em todos os 8 arquivos alterados
- [ ] Revisão visual das páginas afetadas (login, cadastro/perfil de funcionário e dependente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs