### PR TITLE
Fix: IDOR em despachos de memorando, XSS armazenado em Informações Adicionais e bugs correlatos

### DIFF
--- a/web/dao/InformacaoAdicionalDAO.php
+++ b/web/dao/InformacaoAdicionalDAO.php
@@ -10,7 +10,11 @@ class InformacaoAdicionalDAO{
     }
 
     private function montarInformacaoAdicional(array $array){
-        return new InformacaoAdicional($array['id'], $array['descricao'], $array['dado']);
+        return new InformacaoAdicional(
+            $array['id'],
+            htmlspecialchars($array['descricao'] ?? '', ENT_QUOTES, 'UTF-8'),
+            htmlspecialchars($array['dado'] ?? '', ENT_QUOTES, 'UTF-8')
+        );
     }
 
     public function getTodasInformacoesAdicionaisPorIdFuncionario(int $idFuncionario){

--- a/web/html/funcionario/informacao_adicional.php
+++ b/web/html/funcionario/informacao_adicional.php
@@ -44,6 +44,14 @@ if ($action == "adicionar_descricao") {
 }
 
 if ($action == "adicionar") {
+    $dados = trim((string) filter_input(INPUT_POST, 'dados', FILTER_UNSAFE_RAW));
+
+    if (!$dados || strlen($dados) == 0) {
+        http_response_code(400);
+        echo json_encode(['erro' => 'Os dados não podem estar vazios.']);
+        exit();
+    }
+
     $sql = "INSERT INTO funcionario_outrasinfo VALUES (default , :idFuncionario, :idDescricao, :dados)";
     try {
         $stmt = $pdo->prepare($sql);
@@ -104,7 +112,7 @@ function listar(PDO $pdo)
         
         //evitar XSS
         foreach ($informacoes as $index => $informacao) {
-            $informacoes[$index]['dados'] = htmlspecialchars($informacao['dados'] ?? '');
+            $informacoes[$index]['dado'] = htmlspecialchars($informacao['dado'] ?? '');
             $informacoes[$index]['descricao'] = htmlspecialchars($informacao['descricao'] ?? '');
         }
         

--- a/web/html/memorando/listar_despachos.php
+++ b/web/html/memorando/listar_despachos.php
@@ -1,5 +1,7 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
+
 if (session_status() === PHP_SESSION_NONE) {
 	session_start();
 }
@@ -11,7 +13,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 
@@ -41,6 +42,20 @@ $id_memorando = filter_input(INPUT_GET, 'id_memorando', FILTER_VALIDATE_INT);
 if (!$id_memorando || $id_memorando < 1) {
 	http_response_code(400);
 	echo json_encode(['erro' => 'O id do memorando informado não está dentro dos limites permitidos.']);
+	exit();
+}
+
+// Verifica se o usuário é remetente ou destinatário de algum despacho deste
+// memorando ANTES de buscar/embutir qualquer dado na página. A checagem de
+// $_SESSION['memorandoIdInativo'] mais abaixo só trocava o HTML do painel via
+// JavaScript no cliente, o que não impedia que o conteúdo dos despachos já
+// tivesse sido enviado na resposta HTTP (IDOR).
+$acessoMemorando = new MemorandoControle;
+$acessoMemorando->listarIdTodosInativos();
+
+if (!in_array($id_memorando, $_SESSION['memorandoIdInativo'] ?? [])) {
+	http_response_code(403);
+	echo json_encode(['erro' => 'Você não tem acesso a este memorando.']);
 	exit();
 }
 
@@ -585,7 +600,9 @@ require_once ROOT . "/html/personalizacao_display.php";
 										$pdo = Conexao::connect();
 										$memorandosDespachados->listarTodosId($id_memorando);
 										$memorando = $_SESSION['memorandoId'][0];
-										extract($memorando);
+										$titulo = $memorando['titulo'];
+										$id_status_memorando = $memorando['id_status_memorando'];
+										$id_pessoa = $memorando['id_pessoa'];
 										$statusMemorandoControle = new StatusMemorandoControle();
 										$statusMemorando = $statusMemorandoControle->getPorId(intval($id_status_memorando));
 										if ($statusMemorando) {
@@ -622,7 +639,10 @@ require_once ROOT . "/html/personalizacao_display.php";
 
 										$pessoa_destino = $pessoa_destino["nome"] . ($pessoa_destino["sobrenome"] ? (" " . $pessoa_destino["sobrenome"]) : "");
 
-										$pessoa_memorando = $pdo->query("SELECT nome, sobrenome FROM pessoa WHERE id_pessoa=$id_pessoa;")->fetch(PDO::FETCH_ASSOC);
+										$stmtPessoaMemorando = $pdo->prepare("SELECT nome, sobrenome FROM pessoa WHERE id_pessoa=:idPessoa");
+										$stmtPessoaMemorando->bindValue(':idPessoa', $id_pessoa, PDO::PARAM_INT);
+										$stmtPessoaMemorando->execute();
+										$pessoa_memorando = $stmtPessoaMemorando->fetch(PDO::FETCH_ASSOC);
 
 										$pessoa_memorando = $pessoa_memorando["nome"] . ($pessoa_memorando["sobrenome"] ? (" " . $pessoa_memorando["sobrenome"]) : "");
 

--- a/web/html/pessoa/editar_endereco.php
+++ b/web/html/pessoa/editar_endereco.php
@@ -1,5 +1,4 @@
 <?php
-error_log("Entrou no editar_endereco.php com id_pessoa: " . $_POST['id_pessoa']);
 session_start();
 if (!isset($_SESSION["usuario"])){
     header("Location: ../../index.php");
@@ -18,14 +17,18 @@ $pdo = Conexao::connect();
 
 extract($_POST);
 
-$cep = ($cep ? "'$cep'" : "NULL");
-$uf = ($uf ? "'$uf'" : "NULL");
-$cidade = ($cidade ? "'$cidade'" : "NULL");
-$bairro = ($bairro ? "'$bairro'" : "NULL");
-$rua = ($rua ? "'$rua'" : "NULL");
-$complemento = ($complemento ? "'$complemento'" : "NULL");
-$ibge = ($ibge ? "'$ibge'" : "NULL");
-$numero_residencia = ($numero_residencia ? "'$numero_residencia'" : "'Não possui'");
+// Os valores são passados como parâmetros vinculados (prepared statement),
+// então não devem ser envolvidos em aspas manualmente — isso só fazia o
+// banco gravar as aspas como parte do próprio valor. Campos vazios viram
+// NULL de verdade (antes viravam a string literal "NULL").
+$cep = $cep ? $cep : null;
+$uf = $uf ? $uf : null;
+$cidade = $cidade ? $cidade : null;
+$bairro = $bairro ? $bairro : null;
+$rua = $rua ? $rua : null;
+$complemento = $complemento ? $complemento : null;
+$ibge = $ibge ? $ibge : null;
+$numero_residencia = $numero_residencia ? $numero_residencia : 'Não possui';
 
 $stmt = $pdo->prepare("UPDATE pessoa SET cep=:cep, estado=:uf, cidade=:cidade, bairro=:bairro, logradouro=:rua, complemento=:complemento, ibge=:ibge, numero_endereco=:numero_residencia WHERE id_pessoa=:id_pessoa");
 
@@ -41,7 +44,6 @@ $stmt->bindParam(':id_pessoa', $id_pessoa);
 
 $stmt->execute();
 
-$_GET['sql'] = $sql;
-echo(json_encode($_GET));
+echo json_encode(['sucesso' => true]);
 
 ?>


### PR DESCRIPTION
## Resumo

Corrige vulnerabilidades reais encontradas ao investigar as issues #274 e #290 (que continham majoritariamente relatos genéricos/desatualizados de IA, mas apontavam na direção certa).

## Vulnerabilidades corrigidas

**IDOR em `listar_despachos.php`** (refs #274): qualquer funcionário com permissão genérica no módulo de memorando conseguia ler o conteúdo de despachos de terceiros (texto, remetente, destinatário, anexos) só trocando o `id_memorando` na URL — os dados eram embutidos na resposta HTML antes de qualquer checagem de participação; a checagem existente só escondia o painel via JS no cliente. Agora valida server-side, antes de buscar qualquer dado, se o usuário é remetente/destinatário de algum despacho do memorando (reaproveitando `MemorandoDAO::listarIdTodosInativos`, já usada e testada para esse fim). Também troca uma query com interpolação SQL crua por prepared statement e remove um `extract()` sobre linha do banco.

**XSS armazenado em "Informações Adicionais" do funcionário** (refs #290): o campo `dado` não era escapado nem na escrita (`informacao_adicional.php`, `action=adicionar`) nem na leitura usada pela tela atual (`InformacaoAdicionalDAO::getTodasInformacoesAdicionaisPorIdFuncionario`). Corrigido escapando na leitura (mesmo padrão já usado no endpoint legado) e adicionada validação de campo vazio na escrita. De quebra, corrigido um typo no endpoint legado (escapava para a chave `'dados'`, que não existe, deixando a chave real `'dado'` sem escape) — não era explorável hoje, mas era a mesma falha dormente.

**`editar_endereco.php`**: removido `error_log` que vazava `$_POST` cru antes da autenticação e código morto que referenciava variável inexistente; removidas aspas literais manuais em volta dos valores vinculados via prepared statement, que faziam o banco gravar as aspas como parte do próprio valor (ex: cep salvo como `"'28625-520'"`), e campos vazios agora viram `NULL` de verdade em vez da string literal `"NULL"`.

**`listar_despachos.php`**: corrigida constante `WWW` usada antes de `config.php` ser carregado, causando Fatal Error (em vez de redirecionar ao login) quando a sessão é inválida.

## Test plan

Todas as correções foram testadas manualmente na instância local:
- [x] Acesso legítimo a memorando continua funcionando (participante vê o conteúdo normal)
- [x] Acesso de não-participante é bloqueado com 403 e sem vazamento de dados (testado com conta real logada)
- [x] Payload de XSS volta escapado nos dois endpoints de Informações Adicionais
- [x] Endereço é salvo sem aspas espúrias e com NULL real para campos vazios
- [x] Página redireciona corretamente (302) em vez de Fatal Error sem sessão válida
- [x] `php -l` limpo em todos os arquivos alterados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs