### PR TITLE
Fix: SQL injection e XSS armazenado em DAOs (Atendido_ocorrenciaDoc, Endereco, Memorando)

### DIFF
--- a/web/dao/Atendido_ocorrenciaDocDAO.php
+++ b/web/dao/Atendido_ocorrenciaDocDAO.php
@@ -24,7 +24,9 @@ class Atendido_ocorrenciaDocDAO
 	 	try{
 			$Anexos = array();
 			$pdo = Conexao::connect();
-			$consulta = $pdo->query("SELECT arquivo_nome, arquivo_extensao FROM `atendido_ocorrencia_doc` WHERE atentido_ocorrencia_idatentido_ocorrencias = $idatendido_ocorrencias");
+			$consulta = $pdo->prepare("SELECT arquivo_nome, arquivo_extensao FROM `atendido_ocorrencia_doc` WHERE atentido_ocorrencia_idatentido_ocorrencias = :idatendido_ocorrencias");
+			$consulta->bindParam(':idatendido_ocorrencias', $idatendido_ocorrencias, PDO::PARAM_INT);
+			$consulta->execute();
 			$x = 0;
 			
 			while($linha = $consulta->fetch(PDO::FETCH_ASSOC))

--- a/web/dao/EnderecoDAO.php
+++ b/web/dao/EnderecoDAO.php
@@ -49,7 +49,10 @@ class EnderecoDAO
             $id = new EnderecoDAO;
             $numeroId = $id->listarId();
             $numeroId = $numeroId[0]['id'];
-            $consulta = $pdo->query("SELECT bairro, cep, cidade, complemento, estado, ibge, logradouro, nome, numero_endereco FROM endereco_instituicao WHERE id_inst='$numeroId'");
+            $stmtEndereco = $pdo->prepare("SELECT bairro, cep, cidade, complemento, estado, ibge, logradouro, nome, numero_endereco FROM endereco_instituicao WHERE id_inst=:id_inst");
+            $stmtEndereco->bindParam(':id_inst', $numeroId);
+            $stmtEndereco->execute();
+            $consulta = $stmtEndereco;
             $endereco = Array();
             $x=0;
             while($linha = $consulta->fetch(PDO::FETCH_ASSOC)){
@@ -69,12 +72,11 @@ class EnderecoDAO
             $id = new EnderecoDAO;
             $numeroId = $id->listarId();
             $numeroId = $numeroId[0]['id'];
-            $sql = "update endereco_instituicao set nome=:nome,numero_endereco=:numero_endereco,logradouro=:logradouro,bairro=:bairro,cidade=:cidade,estado=:estado,cep=:cep,complemento=:complemento,ibge=:ibge where id_inst='$numeroId'";
-            
+            $sql = "update endereco_instituicao set nome=:nome,numero_endereco=:numero_endereco,logradouro=:logradouro,bairro=:bairro,cidade=:cidade,estado=:estado,cep=:cep,complemento=:complemento,ibge=:ibge where id_inst=:id_inst";
+
             $pdo = Conexao::connect();
             $stmt = $pdo->prepare($sql);
-            
-            $stmt = $pdo->prepare($sql);
+            $stmt->bindParam(':id_inst', $numeroId);
             $nome=$endereco->getNome();
             $cep=$endereco->getCep();
             $estado=$endereco->getEstado();

--- a/web/dao/memorando/MemorandoDAO.php
+++ b/web/dao/memorando/MemorandoDAO.php
@@ -37,6 +37,10 @@ class MemorandoDAO
 
 			if ($resultado) {
 				$Memorandos = $resultado;
+
+				foreach ($Memorandos as $key => $value) {
+					$Memorandos[$key]['titulo'] = htmlspecialchars($value['titulo']);
+				}
 			}
 		} catch (PDOException $e) {
 			echo 'Error:' . $e->getMessage();


### PR DESCRIPTION
## Resumo

Corrige vulnerabilidades reais encontradas ao revisar as 25 issues de segurança do lote `web/dao/*.php`.

## Vulnerabilidades corrigidas

- **`Atendido_ocorrenciaDocDAO.php::listarTodos()`**: SQL injection clássica via interpolação direta de `$idatendido_ocorrencias` na query. Convertido para prepared statement com bind. Único chamador está comentado hoje (código morto), mas a correção é trivial e segura.
- **`EnderecoDAO.php::listarInstituicao()`/`alterarEndereco()`**: `id_inst` interpolado direto na query (valor vem do próprio banco, não é input direto de usuário, mas o padrão inseguro foi eliminado por consistência e defesa em profundidade).
- **`memorando/MemorandoDAO.php::listarTodos()`**: `titulo` do memorando não era escapado — stored XSS confirmado, já que `listar_memorandos_ativos.php` insere `item.titulo` via `.html()` sem escape adicional no frontend. Adicionado `htmlspecialchars`, mesmo padrão que `listarTodosInativos()` já usava no mesmo arquivo.

As demais 22 issues do lote foram revisadas e confirmadas falso-positivo (uso consistente de prepared statements com bind) ou obsoletas (arquivo movido: `dao/memorando/adicionar_cor.php` → `dao/pet/adicionar_cor.php`).

## Test plan

- [x] `php -l` limpo em todos os arquivos alterados
- [ ] Revisão funcional: listagem de endereço da instituição, listagem de memorandos ativos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs