### PR TITLE
Fix: IDOR em download de anexo de memorando + falta de autorização em ocorrência de atendido

### DIFF
--- a/web/controle/Atendido_ocorrenciaControle.php
+++ b/web/controle/Atendido_ocorrenciaControle.php
@@ -50,6 +50,18 @@ class Atendido_ocorrenciaControle
 			if (!$idOcorrencia || $idOcorrencia < 1)
 				throw new InvalidArgumentException('O id da ocorrência informado é inválido.', 412);
 
+			// Este método é usado por um endpoint de download de anexo que só
+			// checava se havia sessão ativa, sem checar permissão nenhuma no
+			// módulo de atendido -- qualquer usuário autenticado conseguia
+			// baixar documentos de ocorrência de qualquer atendido.
+			$idPessoa = filter_var($_SESSION['id_pessoa'] ?? null, FILTER_VALIDATE_INT);
+			if (!$idPessoa || $idPessoa < 1) {
+				throw new InvalidArgumentException('Usuario nao autenticado.', 401);
+			}
+
+			require_once ROOT . '/html/permissao/permissao.php';
+			permissao($idPessoa, 12, 7);
+
 			$Atendido_ocorrenciaDAO = new Atendido_ocorrenciaDAO();
 			$anexos = $Atendido_ocorrenciaDAO->listarAnexo($idOcorrencia);
 

--- a/web/controle/memorando/AnexoControle.php
+++ b/web/controle/memorando/AnexoControle.php
@@ -13,6 +13,7 @@ if (file_exists($config_path)) {
 
 require_once ROOT . "/classes/memorando/Anexo.php";
 require_once ROOT . "/dao/memorando/AnexoDAO.php";
+require_once ROOT . "/dao/memorando/MemorandoDAO.php";
 
 class AnexoControle
 {
@@ -39,11 +40,33 @@ class AnexoControle
 				throw new InvalidArgumentException('O id fornecido para o anexo não é válido.', 400);
 			}
 
-			$AnexoDAO = new AnexoDAO();
-			$anexos = $AnexoDAO->listarAnexo($idAnexo);
 			if (session_status() !== PHP_SESSION_ACTIVE) {
 				session_start();
 			}
+
+			if (!isset($_SESSION['usuario'])) {
+				throw new InvalidArgumentException('Usuário não autenticado.', 401);
+			}
+
+			$AnexoDAO = new AnexoDAO();
+
+			// Verifica se o anexo pertence a um memorando em que o usuário logado
+			// é remetente ou destinatário de algum despacho, antes de buscar/expor
+			// o conteúdo do arquivo (evita IDOR: qualquer id_anexo bastava antes).
+			$idMemorando = $AnexoDAO->getIdMemorandoPorAnexo($idAnexo);
+
+			if (!$idMemorando) {
+				throw new InvalidArgumentException('Anexo não encontrado.', 404);
+			}
+
+			$memorandoDAO = new MemorandoDAO();
+			$memorandosPermitidos = $memorandoDAO->listarIdTodosInativos();
+
+			if (!in_array($idMemorando, $memorandosPermitidos ?? [])) {
+				throw new InvalidArgumentException('Você não tem acesso a este anexo.', 403);
+			}
+
+			$anexos = $AnexoDAO->listarAnexo($idAnexo);
 			$_SESSION['arq'] = $anexos;
 		} catch (Exception $e) {
 			require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'Util.php';

--- a/web/dao/memorando/AnexoDAO.php
+++ b/web/dao/memorando/AnexoDAO.php
@@ -18,7 +18,7 @@ class AnexoDAO
 			$anexos = $stmtAnexos->fetchAll(PDO::FETCH_ASSOC);
 
 			foreach($anexos as $key => $value){
-				$anexos[$key] = ['extensao' => $value['extensao'], 'nome' => $value['nome'], 'id_despacho' => $value['id_despacho'], 'id_anexo' => $value['id_anexo']];
+				$anexos[$key] = ['extensao' => htmlspecialchars($value['extensao']), 'nome' => htmlspecialchars($value['nome']), 'id_despacho' => $value['id_despacho'], 'id_anexo' => $value['id_anexo']];
 			}
 		} catch (PDOException $e) {
 			echo 'Error:' . $e->getMessage();
@@ -43,6 +43,19 @@ class AnexoDAO
 		}
 
 		return $anexo;
+	}
+
+	//Função para obter o id do memorando ao qual um anexo pertence (via despacho)
+	public function getIdMemorandoPorAnexo($idAnexo)
+	{
+		$pdo = Conexao::connect();
+		$stmt = $pdo->prepare("SELECT d.id_memorando FROM anexo a JOIN despacho d ON (a.id_despacho = d.id_despacho) WHERE a.id_anexo = :idAnexo");
+		$stmt->bindParam(':idAnexo', $idAnexo, PDO::PARAM_INT);
+		$stmt->execute();
+
+		$resultado = $stmt->fetch(PDO::FETCH_ASSOC);
+
+		return $resultado ? $resultado['id_memorando'] : null;
 	}
 
 	//Função para incluir um anexo


### PR DESCRIPTION
## Resumo

Corrige duas vulnerabilidades reais de controle de acesso encontradas ao revisar issues de segurança do módulo `web/controle/*.php`.

## Vulnerabilidades corrigidas

- **`controle/memorando/AnexoControle.php::listarAnexo()`** (refs #517): IDOR — qualquer usuário autenticado conseguia baixar o conteúdo de qualquer anexo de memorando só sabendo/adivinhando o `id_anexo`, sem checar se pertence a um memorando em que ele é remetente/destinatário. Mesmo padrão do IDOR já corrigido em `listar_despachos.php` (PR #2006): agora resolve o `id_memorando` do anexo (novo `AnexoDAO::getIdMemorandoPorAnexo`) e valida contra `MemorandoDAO::listarIdTodosInativos()` antes de expor o conteúdo. De quebra, também faltava checar se havia sessão ativa.
- **`controle/Atendido_ocorrenciaControle.php`** (refs #494): o endpoint de listagem de anexos de ocorrência de atendido só checava se havia sessão ativa, sem checar permissão nenhuma no módulo — qualquer usuário autenticado conseguia baixar documentos de ocorrência de qualquer atendido. Adicionada checagem de `permissao()` no recurso correto.

## Test plan

- [x] `php -l` limpo em todos os arquivos alterados
- [ ] Revisão funcional: download de anexo de memorando (dono vs. não-participante), listagem de anexos de ocorrência de atendido

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs