### PR TITLE
Fix: endpoints do módulo pet sem checagem de autenticação nenhuma

### DIFF
--- a/web/controle/pet/ControleHistorico.php
+++ b/web/controle/pet/ControleHistorico.php
@@ -1,4 +1,12 @@
 <?php
+if (session_status() === PHP_SESSION_NONE)
+    session_start();
+
+if (!isset($_SESSION['id_pessoa'])) {
+    http_response_code(401);
+    die(json_encode(['erro' => 'Operação negada: Cliente não autorizado']));
+}
+
 require_once "./controleSaudePet.php";
 
 $dados = json_decode(file_get_contents("php://input"));

--- a/web/controle/pet/ControleObterAdotante.php
+++ b/web/controle/pet/ControleObterAdotante.php
@@ -1,4 +1,12 @@
 <?php
+if (session_status() === PHP_SESSION_NONE)
+    session_start();
+
+if (!isset($_SESSION['id_pessoa'])) {
+    http_response_code(401);
+    die(json_encode(['erro' => 'Operação negada: Cliente não autorizado']));
+}
+
 require_once 'AdocaoControle.php';
 
 $post = json_decode(file_get_contents("php://input"), true);

--- a/web/controle/pet/PetExameControle.php
+++ b/web/controle/pet/PetExameControle.php
@@ -3,6 +3,14 @@ ini_set('display_errors',1);
 ini_set('display_startup_erros',1);
 error_reporting(E_ALL);
 
+if (session_status() === PHP_SESSION_NONE)
+    session_start();
+
+if (!isset($_SESSION['id_pessoa'])) {
+    http_response_code(401);
+    die(json_encode(['erro' => 'Operação negada: Cliente não autorizado']));
+}
+
 $PetDAO_path = "dao/pet/PetDAO.php";
 if(file_exists($PetDAO_path)){
     require_once($PetDAO_path);

--- a/web/controle/pet/RGControle.php
+++ b/web/controle/pet/RGControle.php
@@ -1,4 +1,12 @@
 <?php
+if (session_status() === PHP_SESSION_NONE)
+    session_start();
+
+if (!isset($_SESSION['id_pessoa'])) {
+    http_response_code(401);
+    die(json_encode(['erro' => 'Operação negada: Cliente não autorizado']));
+}
+
 require_once 'AdocaoControle.php';
 
 $post = file_get_contents( 'php://input');

--- a/web/controle/pet/controleGetMedicamento.php
+++ b/web/controle/pet/controleGetMedicamento.php
@@ -2,6 +2,11 @@
 if (session_status() === PHP_SESSION_NONE)
     session_start();
 
+if (!isset($_SESSION['id_pessoa'])) {
+    http_response_code(401);
+    die(json_encode(['erro' => 'Operação negada: Cliente não autorizado']));
+}
+
 require_once './MedicamentoControle.php';
 header("Content-Type: application/json;charset=UTF-8");
 

--- a/web/controle/pet/controleGetPet.php
+++ b/web/controle/pet/controleGetPet.php
@@ -2,6 +2,11 @@
 if (session_status() === PHP_SESSION_NONE)
     session_start();
 
+if (!isset($_SESSION['id_pessoa'])) {
+    http_response_code(401);
+    die(json_encode(['erro' => 'Operação negada: Cliente não autorizado']));
+}
+
 require_once "./controleSaudePet.php";
 
 $post = json_decode(file_get_contents("php://input"));


### PR DESCRIPTION
## Resumo

Corrige uma vulnerabilidade real e séria encontrada ao revisar as issues de segurança do módulo pet (refs #509, #508, #502, #501, #511, #510): seis endpoints de controle não checavam se havia usuário logado antes de ler/alterar dados — qualquer visitante não autenticado conseguia acessá-los diretamente.

## Vulnerabilidade corrigida

Adicionada checagem mínima de sessão ativa (`$_SESSION['id_pessoa']`, retornando 401 caso contrário) em:

- `controle/pet/ControleHistorico.php` — histórico de saúde do pet
- `controle/pet/ControleObterAdotante.php` — dados de adotante
- `controle/pet/PetExameControle.php` — exames do pet
- `controle/pet/RGControle.php` — RG do pet
- `controle/pet/controleGetMedicamento.php` — busca de medicamento
- `controle/pet/controleGetPet.php` — busca de pet

## Test plan

- [x] `php -l` limpo em todos os arquivos alterados
- [ ] Revisão funcional: acesso autenticado às telas de pet continua funcionando normalmente; acesso direto aos endpoints sem login retorna 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs