### PR TITLE
Fix: gate de autenticação quebrado (falta de exit) e upload de documento sem sanitização

### DIFF
--- a/web/html/configuracao/atualizacao.php
+++ b/web/html/configuracao/atualizacao.php
@@ -3,7 +3,8 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
 Util::definirFusoHorario();
 session_start();
     if (!isset($_SESSION['usuario'])) {
-        header("Location ../../index.php");
+        header("Location: ../../index.php");
+        exit();
     }
 
     // Verifica Permissão do Usuário

--- a/web/html/configuracao/correcao_estoque.php
+++ b/web/html/configuracao/correcao_estoque.php
@@ -2,6 +2,7 @@
     session_start();
     if (!isset($_SESSION['usuario'])){
         header("Location: ../../index.php");
+        exit();
 	}
 
 	// Diz ao programa de correção de estoque se deve ou não mostrar os avisos

--- a/web/html/funcionario/dependente_parentesco_listar.php
+++ b/web/html/funcionario/dependente_parentesco_listar.php
@@ -3,6 +3,7 @@
 session_start();
 if (!isset($_SESSION["usuario"])) {
     header("Location: ../../index.php");
+    exit();
 }
 
 // Verifica Permissão do Usuário

--- a/web/html/funcionario/docdependente_upload.php
+++ b/web/html/funcionario/docdependente_upload.php
@@ -19,24 +19,37 @@ if ($_POST) {
     require_once "../../dao/Conexao.php";
 
     // $id_dependente, $id_docdependente e $arquivo
-    extract($_POST);
-
-    // A tabela funcioanrio_docs requer id_dependente, id_docdependente, extensao_arquivo, nome_arquivo e arquivo
-    $id_dependente = filter_var($id_dependente, FILTER_VALIDATE_INT);
-    $id_docdependente = filter_var($id_docdependente, FILTER_VALIDATE_INT);
+    $id_dependente = filter_input(INPUT_POST, 'id_dependente', FILTER_VALIDATE_INT);
+    $id_docdependente = filter_input(INPUT_POST, 'id_docdependente', FILTER_VALIDATE_INT);
     $arquivo = $_FILES["arquivo"];
-    $nome_arquivo = $arquivo["name"];
-    $mime_type = $arquivo["type"];
-    $extensao_arquivo = explode(".", $arquivo["name"])[1];
+
+    // Sanitiza o nome do arquivo enviado: remove diretórios, caracteres de
+    // controle e caracteres inseguros antes de gravar no banco de dados.
+    $nome_arquivo = basename(trim((string) $arquivo["name"]));
+    $nome_arquivo = preg_replace('/[[:cntrl:]]+/', '', $nome_arquivo);
+    $nome_arquivo = str_replace(['\\', '/', ':', '*', '?', '"', '<', '>', '|'], '_', $nome_arquivo);
+
+    $extensao_arquivo = strtolower(pathinfo($nome_arquivo, PATHINFO_EXTENSION));
+
+    // O tipo MIME informado pelo cliente não é confiável; valida o conteúdo real do arquivo.
+    $mime_type = false;
+    if (isset($arquivo['tmp_name']) && is_uploaded_file($arquivo['tmp_name'])) {
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+        $mime_type = $finfo->file($arquivo['tmp_name']);
+    }
     $arquivo_b64 = base64_encode(file_get_contents($arquivo['tmp_name']));
 
     $data = date('Y-m-d H:i:s', time());
     try {
-        if ($id_dependente <= 0) {
+        if (!$id_dependente || $id_dependente <= 0) {
             throw new Exception("ID do dependente inválido.", 400);
         }
-        if ($id_docdependente <= 0) {
+        if (!$id_docdependente || $id_docdependente <= 0) {
             throw new Exception("ID do documento do dependente inválido.", 400);
+        }
+
+        if ($nome_arquivo === '' || $nome_arquivo === '.' || $nome_arquivo === '..') {
+            throw new Exception("Nome de arquivo inválido.", 400);
         }
 
         if (!in_array($extensao_arquivo, ['pdf', 'jpg', 'jpeg', 'png'])) {


### PR DESCRIPTION
## Resumo

Corrige vulnerabilidades reais encontradas ao revisar issues de segurança diversas do módulo `html/`.

## Vulnerabilidades corrigidas

- **`html/configuracao/atualizacao.php`** (refs #341): o redirect de "não autenticado" usava `header("Location ../../index.php")` sem os dois-pontos depois de "Location" — um header inválido, que o navegador simplesmente ignora. Sem `exit()` depois, a checagem de sessão não bloqueava nada: qualquer visitante não autenticado conseguia executar a página de atualização do sistema. Corrigido o header e adicionado `exit()`.
- **`html/configuracao/correcao_estoque.php`** (refs #337) e **`html/funcionario/dependente_parentesco_listar.php`** (refs #303): mesmo padrão de bug — `header("Location: ...")` correto, mas sem `exit()` depois, então a execução continuava normalmente mesmo sem sessão válida. Adicionado `exit()`.
- **`html/funcionario/docdependente_upload.php`** (refs #301): nome do arquivo enviado era usado sem sanitização (risco de path traversal/caracteres perigosos no nome gravado no banco) e o tipo do arquivo era validado só pela extensão e pelo MIME type informado pelo próprio cliente (facilmente forjável). Agora o nome é sanitizado (remove diretórios, caracteres de controle e caracteres inseguros) e o tipo real do arquivo é verificado via `finfo`/conteúdo, não mais confiando no que o navegador informa.

## Test plan

- [x] `php -l` limpo em todos os arquivos alterados
- [ ] Revisão funcional: acesso sem sessão às 3 páginas afetadas redireciona corretamente; upload de documento de dependente com arquivo válido continua funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs