### PR TITLE
Fix: gate de autenticação sem exit() em atendido_parentesco_listar.php e informacao_funcionario.php

### DIFF
--- a/web/html/atendido/atendido_parentesco_listar.php
+++ b/web/html/atendido/atendido_parentesco_listar.php
@@ -5,6 +5,7 @@ if (session_status() === PHP_SESSION_NONE) {
 
 if (!isset($_SESSION["usuario"])) {
     header("Location: ../../index.php");
+    exit();
 }else{
     session_regenerate_id();
 } 

--- a/web/html/funcionario/informacao_funcionario.php
+++ b/web/html/funcionario/informacao_funcionario.php
@@ -9,12 +9,14 @@ if (session_status() === PHP_SESSION_NONE)
 
 if (!isset($_SESSION['usuario'])) {
 	header("Location: ../index.php");
+	exit();
 } else {
 	session_regenerate_id();
 }
 
 if (!isset($_SESSION['funcionarios'])) {
 	header('Location: ../../controle/control.php?metodo=listartodos&nomeClasse=FuncionarioControle&nextPage=../html/funcionario/informacao_funcionario.php');
+	exit();
 }
 
 require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';


### PR DESCRIPTION
## Resumo

Corrige vulnerabilidades reais encontradas ao revisar 15 issues de segurança diversas do módulo `html/`.

## Vulnerabilidades corrigidas

- **`html/atendido/atendido_parentesco_listar.php`** (refs #376): `header("Location...")` sem `exit()` — a checagem de sessão não bloqueava a execução.
- **`html/funcionario/informacao_funcionario.php`** (refs #293): dois `header("Location...")` sem `exit()`, incluindo o **gate de autenticação principal** (`$_SESSION['usuario']`). Na prática o `permissao()` subsequente acabava barrando por acaso, mas o padrão estava quebrado exatamente como os outros bugs desse tipo já corrigidos hoje.

As demais 13 issues do lote (#347, #340, #332, #314, #297, #296, #295, #280, #278, #254, #253, #252, #270) foram revisadas e confirmadas falso-positivo/já mitigadas — a maioria já bem protegida (sessão+`exit()`, `permissao()`, prepared statements, `htmlspecialchars`).

## Test plan

- [x] `php -l` limpo em ambos os arquivos
- [ ] Acesso sem sessão a ambas as páginas redireciona corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs