### PR TITLE
Fix: SQL injection sem autenticação em cadastro_cobranca_m.php e outras falhas no módulo sócio

### DIFF
--- a/web/html/socio/sistema/cadastro_cobranca_m.php
+++ b/web/html/socio/sistema/cadastro_cobranca_m.php
@@ -1,4 +1,12 @@
 <?php
+    if (session_status() === PHP_SESSION_NONE)
+        session_start();
+
+    if (!isset($_SESSION['usuario'])) {
+        http_response_code(401);
+        exit('Não autenticado.');
+    }
+
     require("../conexao.php");
     if(!isset($_POST) or empty($_POST)){
         $data = file_get_contents( "php://input" );
@@ -10,25 +18,25 @@
     $cadastrado =  false;
     extract($_REQUEST);
     if(!isset($data_doacao) or ($data_doacao == null) or ($data_doacao == "") or empty($data_doacao) or ($data_doacao == "imp")){
-        $data_doacao = "null";
-    }else $data_doacao = "'$data_doacao'";
+        $data_doacao = null;
+    }
 
-    if(!isset($valor) or ($valor == null) or ($valor == "") or empty($valor) or ($valor == "imp")){
+    if(!isset($valor) or ($valor == null) or ($valor == "") or empty($valor) or ($valor == "imp") or !is_numeric($valor)){
         $valor = 0;
-    }else $valor = $valor;
+    }
 
-    // Lidando com aspas simples e duplas
-    $socio_nome = addslashes($socio_nome);
-    $local_recepcao = addslashes($local_recepcao);
+    $socio_id = filter_var($socio_id, FILTER_SANITIZE_NUMBER_INT);
+    $descricao = "PAGO EM $local_recepcao, $forma_doacao, RECEBIDO POR $receptor";
     $codigo = rand() * -1;
 
-    $stmt = mysqli_prepare($conexao, "INSERT INTO `cobrancas`(`codigo`, `descricao`, `data_pagamento`, `valor`, `valor_pago`, `status`, `linha_digitavel`, `link_cobranca`, `link_boleto`, `id_socio`) VALUES ($codigo, 'PAGO EM $local_recepcao, $forma_doacao, RECEBIDO POR $receptor', $data_doacao, $valor, $valor, 'PAGO', 'PAGO EM $local_recepcao, $forma_doacao, RECEBIDO POR $receptor', '#', '#', $socio_id)");
-    
+    $stmt = mysqli_prepare($conexao, "INSERT INTO `cobrancas`(`codigo`, `descricao`, `data_pagamento`, `valor`, `valor_pago`, `status`, `linha_digitavel`, `link_cobranca`, `link_boleto`, `id_socio`) VALUES (?, ?, ?, ?, ?, 'PAGO', ?, '#', '#', ?)");
+    mysqli_stmt_bind_param($stmt, "sssddsi", $codigo, $descricao, $data_doacao, $valor, $valor, $descricao, $socio_id);
+
     if($stmt && mysqli_stmt_execute($stmt)){
         if(mysqli_affected_rows($conexao)){
             $cadastrado = true;
         }
     }
-    
+
     echo json_encode($cadastrado);
 ?>

--- a/web/html/socio/sistema/controller/deletar_diretorio_tabelas.php
+++ b/web/html/socio/sistema/controller/deletar_diretorio_tabelas.php
@@ -1,4 +1,12 @@
 <?php
+     if (session_status() === PHP_SESSION_NONE)
+         session_start();
+
+     if (!isset($_SESSION['usuario'])) {
+         http_response_code(401);
+         exit('Não autenticado.');
+     }
+
      function delTree($dir) {
       
         $dir = realpath($dir);

--- a/web/html/socio/sistema/controller/import_conteudo_gerarcontribuicao.php
+++ b/web/html/socio/sistema/controller/import_conteudo_gerarcontribuicao.php
@@ -108,13 +108,13 @@
 
         $dados_contrib = json_encode($registro);
 
-        echo("<input type='hidden' name='dados_contrib' value='$dados_contrib'>");
-        echo("<input type='hidden' name='socio' value='$id_socio'>");
+        echo("<input type='hidden' name='dados_contrib' value='".htmlspecialchars($dados_contrib, ENT_QUOTES, 'UTF-8')."'>");
+        echo("<input type='hidden' name='socio' value='".htmlspecialchars($id_socio, ENT_QUOTES, 'UTF-8')."'>");
     ?>
-        
+
         <div class="box box-info">
             <div class="box-header with-border">
-              <h3 class="box-title">Opções de geração -  Sócio: <?php echo($nome_socio." ($tipo_socio)"); ?></h3>
+              <h3 class="box-title">Opções de geração -  Sócio: <?php echo(htmlspecialchars($nome_socio." ($tipo_socio)", ENT_QUOTES, 'UTF-8')); ?></h3>
             </div>
             <div class="box-body">
             <div class="row">

--- a/web/html/socio/sistema/controller/import_modais_integracao.php
+++ b/web/html/socio/sistema/controller/import_modais_integracao.php
@@ -39,11 +39,11 @@
             <form id="frm_boletofacil">
             <div class="form-group col-xs-12">
           <label for="valor">URL API (ISSUE CHARGE - COBRANÇAS)</label>
-          <input type="text" class="form-control"  value="<?php echo($url); ?>" name="url" required>
+          <input type="text" class="form-control"  value="<?php echo(htmlspecialchars($url, ENT_QUOTES, 'UTF-8')); ?>" name="url" required>
         </div>
         <div class="form-group col-xs-12">
           <label for="valor">TOKEN API</label>
-          <input type="text" class="form-control" value="<?php echo($token); ?>" name="token" required>
+          <input type="text" class="form-control" value="<?php echo(htmlspecialchars($token, ENT_QUOTES, 'UTF-8')); ?>" name="token" required>
         </div>
         <div class="form-group col-xs-6">
           <label for="valor">VAL. MIN. BOLETO UNITÁRIO</label>
@@ -71,7 +71,7 @@
         </div>
         <div class="form-group col-xs-12">
           <label for="valor">MENSAGEM DE AGRADECIMENTO</label>
-          <textarea rows="5" name="agradecimento" class="form-control"><?php echo($agradecimento); ?></textarea>
+          <textarea rows="5" name="agradecimento" class="form-control"><?php echo(htmlspecialchars($agradecimento, ENT_QUOTES, 'UTF-8')); ?></textarea>
         </div>
             </div>
             <!-- /.box-body -->

--- a/web/html/socio/sistema/exibir_tags.php
+++ b/web/html/socio/sistema/exibir_tags.php
@@ -1,4 +1,12 @@
 <?php
+    if (session_status() === PHP_SESSION_NONE)
+        session_start();
+
+    if (!isset($_SESSION['usuario'])) {
+        http_response_code(401);
+        exit('Não autenticado.');
+    }
+
     require_once('../conexao.php');
     $dados = [];
     $query = mysqli_query($conexao, "SELECT * FROM socio_tag");

--- a/web/html/socio/sistema/payment/notification.php
+++ b/web/html/socio/sistema/payment/notification.php
@@ -39,8 +39,14 @@
                 // precisa adicionar o campo referencia no bd e o campo status
                 $referencia = $retorno['data']['payment']['charge']['reference'];
                 $status = $retorno['data']['payment']['status'];
-                if(mysqli_num_rows(mysqli_query($conexao, "SELECT * FROM `log_contribuicao` WHERE referencia = '$referencia'"))){
-                    $resultado = mysqli_query($conexao, "UPDATE `log_contribuicao` SET `status`= '$status' WHERE referencia = '$referencia'") or die(mysqli_connect_error());
+                $stmtCheck = mysqli_prepare($conexao, "SELECT * FROM `log_contribuicao` WHERE referencia = ?");
+                mysqli_stmt_bind_param($stmtCheck, "s", $referencia);
+                mysqli_stmt_execute($stmtCheck);
+                mysqli_stmt_store_result($stmtCheck);
+                if(mysqli_stmt_num_rows($stmtCheck)){
+                    $stmtUpdate = mysqli_prepare($conexao, "UPDATE `log_contribuicao` SET `status`= ? WHERE referencia = ?");
+                    mysqli_stmt_bind_param($stmtUpdate, "ss", $status, $referencia);
+                    $resultado = mysqli_stmt_execute($stmtUpdate) or die(mysqli_connect_error());
                 }else{
                     // Ainda não sei o que fazer caso entre o pagamento de uma pessoa não cadastrada
                 }

--- a/web/html/socio/sistema/processa_cobrancas_tabela.php
+++ b/web/html/socio/sistema/processa_cobrancas_tabela.php
@@ -1,4 +1,12 @@
 <?php
+    if (session_status() === PHP_SESSION_NONE)
+        session_start();
+
+    if (!isset($_SESSION['usuario'])) {
+        http_response_code(401);
+        exit('Não autenticado.');
+    }
+
     require("../conexao.php");
     if(!isset($_POST) or empty($_POST)){
         $data = file_get_contents( "php://input" );


### PR DESCRIPTION
## Resumo

Corrige vulnerabilidades reais e sérias encontradas ao revisar as 30 issues de segurança do módulo `html/socio`.

## Vulnerabilidades corrigidas

- **`cadastro_cobranca_m.php`** (refs #185) — **a mais séria do lote**: `mysqli_prepare()` era chamado com a string SQL já toda interpolada (sem nenhum `?`) — SQL injection real e completo em `forma_doacao`/`receptor`/`valor`/`socio_id`/`data_doacao` — **e o endpoint não checava sessão nenhuma**, então qualquer visitante não autenticado podia inserir registros arbitrários na tabela `cobrancas`. Corrigido para bind real e adicionado check de login.
- **`payment/notification.php`** (refs #190): webhook de pagamento montava SQL (SELECT/UPDATE em `log_contribuicao`) por concatenação de string com dados da resposta da API de pagamento. Convertido para prepared statements.
- **`controller/deletar_diretorio_tabelas.php`** (refs #214), **`exibir_tags.php`** (refs #175) e **`processa_cobrancas_tabela.php`** (refs #163): endpoints sem checagem de sessão nenhuma — o último expunha nome/valor/status de pagamento de todos os sócios para qualquer requisição direta. Adicionado check de login nos três.
- **`controller/import_conteudo_gerarcontribuicao.php`** (refs #210) e **`controller/import_modais_integracao.php`** (refs #200): XSS armazenado — nome do sócio e configuração do gateway de boleto ecoados sem `htmlspecialchars`. Corrigido.

## Precisa de decisão sua (não corrigido)

**#206** (`controller/import_conteudo_processacontribuicao.php`): o token da API do gateway de boleto é embutido direto em JS client-side (visível no código-fonte da página) para o funcionário gerar o boleto. Além disso, a maior parte das variáveis usadas nesse bloco JS não são atribuídas em lugar nenhum do fluxo atual — parece código morto/quebrado de um refactor incompleto. Corrigir isso direito exige entender a intenção original do fluxo e mexe em lógica de pagamento ativa, por isso não toquei.

As demais 22 issues do lote foram confirmadas falso-positivo (prepared statements + `htmlspecialchars` já presentes), e #150 (`socio/login.php`) está obsoleta — login foi consolidado em `web/html/login.php`.

## Test plan

- [x] `php -l` limpo em todos os 7 arquivos alterados
- [ ] Cadastro de cobrança/doação continua funcionando com dados válidos
- [ ] Acesso sem sessão aos 3 endpoints antes desprotegidos agora é bloqueado
- [ ] Notificação de pagamento (webhook) continua processando corretamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs