### PR TITLE
Fix: IDOR de leitura e escrita em memorando/despacho via control.php

### DIFF
--- a/web/controle/memorando/DespachoControle.php
+++ b/web/controle/memorando/DespachoControle.php
@@ -13,10 +13,52 @@ require_once ROOT . "/classes/Util.php";
 
 class DespachoControle
 {
+	/**
+	 * Verifica se o usuário logado na sessão pode acessar/alterar despachos de um
+	 * memorando: precisa ser quem criou o memorando ou já ter participado dele
+	 * como remetente/destinatário de algum despacho. Isso é checado aqui (e não
+	 * só na página que consome esta classe) porque este método também é
+	 * alcançável diretamente via controle/control.php?nomeClasse=DespachoControle,
+	 * que só valida permissão genérica no módulo (recurso 3), sem checar o
+	 * registro específico -- mesmo padrão do IDOR já corrigido em
+	 * AnexoControle::listarAnexo.
+	 */
+	private function usuarioTemAcessoAoMemorando($id_memorando)
+	{
+		if (session_status() !== PHP_SESSION_ACTIVE) {
+			session_start();
+		}
+
+		$id_memorando = filter_var($id_memorando, FILTER_VALIDATE_INT);
+		$id_pessoa = filter_var($_SESSION['id_pessoa'] ?? null, FILTER_VALIDATE_INT);
+
+		if (!$id_memorando || $id_memorando < 1 || !$id_pessoa || $id_pessoa < 1) {
+			return false;
+		}
+
+		$memorandoDAO = new MemorandoDAO();
+		$dadosMemorando = $memorandoDAO->listarTodosId($id_memorando);
+
+		if (empty($dadosMemorando)) {
+			return false;
+		}
+
+		if ((int)$dadosMemorando[0]['id_pessoa'] === $id_pessoa) {
+			return true;
+		}
+
+		$memorandosPermitidos = $memorandoDAO->listarIdTodosInativos();
+
+		return in_array($id_memorando, $memorandosPermitidos ?? []);
+	}
+
 	//Listar despachos
 	public function listarTodos()
 	{
 		extract($_REQUEST);
+		if (!$this->usuarioTemAcessoAoMemorando($id_memorando)) {
+			throw new InvalidArgumentException('Você não tem acesso a este memorando.', 403);
+		}
 		$despachoDAO = new DespachoDAO();
 		$despachos = $despachoDAO->listarTodos($id_memorando);
 		$_SESSION['despacho'] = $despachos;
@@ -43,6 +85,9 @@ class DespachoControle
 	public function listarTodosComAnexo()
 	{
 		extract($_REQUEST);
+		if (!$this->usuarioTemAcessoAoMemorando($id_memorando)) {
+			throw new InvalidArgumentException('Você não tem acesso a este memorando.', 403);
+		}
 		$despachoComAnexoDAO = new DespachoDAO();
 		$despachosComAnexo = $despachoComAnexoDAO->listarTodosComAnexo($id_memorando);
 		$_SESSION['despachoComAnexo'] = $despachosComAnexo;
@@ -52,6 +97,9 @@ class DespachoControle
 	public function incluir()
 	{
 		extract($_REQUEST);
+		if (!$this->usuarioTemAcessoAoMemorando($id_memorando)) {
+			throw new InvalidArgumentException('Você não tem acesso a este memorando.', 403);
+		}
 		$despacho = $this->verificarDespacho();
 		$despachoDAO = new DespachoDAO();
 		try {
@@ -108,6 +156,10 @@ class DespachoControle
 		try {
 			if ($id < 1) {
 				throw new InvalidArgumentException('O id de um despacho não pode ser menor que 1.', 400);
+			}
+
+			if (!$this->usuarioTemAcessoAoMemorando($id)) {
+				throw new InvalidArgumentException('Você não tem acesso a este memorando.', 403);
 			}
 
 			$despachoDAO = new DespachoDAO();

--- a/web/controle/memorando/MemorandoControle.php
+++ b/web/controle/memorando/MemorandoControle.php
@@ -14,6 +14,7 @@ if (file_exists($config_path)) {
 require_once ROOT . "/dao/memorando/MemorandoDAO.php";
 require_once ROOT . "/classes/memorando/Memorando.php";
 require_once ROOT . "/dao/memorando/UsuarioDAO.php";
+require_once ROOT . "/classes/Util.php";
 
 
 
@@ -96,11 +97,39 @@ class MemorandoControle
     //Alterar status do memorando
     public function alterarIdStatusMemorando()
     {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
         extract($_REQUEST);
-        $memorando = new Memorando('', '', $id_status_memorando, '', '');
-        $memorando->setId_memorando($id_memorando);
-        $memorando->setId_status_memorando($id_status_memorando);
+
+        // Este método é alcançável diretamente via
+        // controle/control.php?nomeClasse=MemorandoControle, que só valida
+        // permissão genérica no módulo (recurso 3), sem checar se o memorando
+        // pertence ao usuário logado -- sem esta checagem, qualquer usuário
+        // com acesso ao módulo conseguia alterar o status de um memorando de
+        // terceiros (IDOR de escrita).
+        $idMemorandoValidado = filter_var($id_memorando ?? null, FILTER_VALIDATE_INT);
+        $idPessoaLogada = filter_var($_SESSION['id_pessoa'] ?? null, FILTER_VALIDATE_INT);
+
+        if (!$idMemorandoValidado || $idMemorandoValidado < 1 || !$idPessoaLogada || $idPessoaLogada < 1) {
+            Util::tratarException(new InvalidArgumentException('O id do memorando informado é inválido.', 400));
+            return;
+        }
+
         $memorandoDAO = new MemorandoDAO();
+        $dadosMemorando = $memorandoDAO->listarTodosId($idMemorandoValidado);
+        $ehCriador = !empty($dadosMemorando) && (int)$dadosMemorando[0]['id_pessoa'] === $idPessoaLogada;
+        $ehParticipante = in_array($idMemorandoValidado, $memorandoDAO->listarIdTodosInativos() ?? []);
+
+        if (!$ehCriador && !$ehParticipante) {
+            Util::tratarException(new InvalidArgumentException('Você não tem acesso a este memorando.', 403));
+            return;
+        }
+
+        $memorando = new Memorando('', '', $id_status_memorando, '', '');
+        $memorando->setId_memorando($idMemorandoValidado);
+        $memorando->setId_status_memorando($id_status_memorando);
         try {
             $memorandoDAO->alterarIdStatusMemorando($memorando);
             header("Location: " . WWW . "html/memorando/listar_memorandos_ativos.php");


### PR DESCRIPTION
## Resumo

Corrige vulnerabilidades reais de controle de acesso encontradas ao revisar 15 issues de segurança do módulo `web/controle/*.php`, que contornavam o fix de IDOR já aplicado hoje em `listar_despachos.php` (PR #2006).

## Vulnerabilidades corrigidas

- **`controle/memorando/DespachoControle.php`** (refs #516): o fix de hoje em `listar_despachos.php` só validava participação naquela página específica — a classe continuava totalmente alcançável direto via `control.php?nomeClasse=DespachoControle` (que só checa permissão genérica de módulo, não o registro), permitindo **ler despachos de memorando de terceiros e inserir despacho em memorando alheio**. Adicionada checagem de autoria/participação em `listarTodos()`, `listarTodosComAnexo()`, `incluir()` e `getPorId()`.
- **`controle/memorando/MemorandoControle.php`** (refs #515, #514): `alterarIdStatusMemorando()` alterava o status de **qualquer** memorando por id, sem checar dono/participante — mesmo vetor via `control.php`. Adicionada a mesma checagem antes do UPDATE.

As demais 12 issues do lote foram confirmadas falso-positivo/já mitigadas (prepared statements, CSRF, hardening já presente), e #480 (`controle/FuncionariosControle.php`) está obsoleta — substituída por `FuncionarioControle.php`.

## Test plan

- [x] `php -l` limpo nos 2 arquivos alterados
- [ ] Participante de memorando continua conseguindo listar/incluir despacho e alterar status normalmente
- [ ] Acesso direto via `control.php` a memorando/despacho de terceiros é bloqueado

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H9xArEk5vXkt8KMBtU83Bs