### PR TITLE
Fix: constante WWW usada antes de config.php (Fatal Error 500 em vez de redirect)

### DIFF
--- a/web/html/funcionario/pre_cadastro_funcionario.php
+++ b/web/html/funcionario/pre_cadastro_funcionario.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
     session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
     session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 permissao($_SESSION['id_pessoa'], 11, 1);
 

--- a/web/html/geral/cargos.php
+++ b/web/html/geral/cargos.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 permissao($_SESSION['id_pessoa'], 91, 1);
 

--- a/web/html/geral/documentos_funcionario.php
+++ b/web/html/geral/documentos_funcionario.php
@@ -1,16 +1,17 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
 
 if (!isset($_SESSION['usuario'])) {
 	header("Location: " . WWW . "index.php");
+	exit();
 } else {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 91, 1);

--- a/web/html/geral/listar_permissoes.php
+++ b/web/html/geral/listar_permissoes.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'Csrf.php';
 

--- a/web/html/geral/modulos_visiveis.php
+++ b/web/html/geral/modulos_visiveis.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 91, 7);

--- a/web/html/matPat/adicionar_unidade.php
+++ b/web/html/matPat/adicionar_unidade.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if(session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 22, 3);

--- a/web/html/matPat/alterar_produto.php
+++ b/web/html/matPat/alterar_produto.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if(session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 22, 3);

--- a/web/html/matPat/cadastro_entrada.php
+++ b/web/html/matPat/cadastro_entrada.php
@@ -1,16 +1,17 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
 
 if (!isset($_SESSION['usuario'])) {
 	header("Location: " . WWW . "html/index.php");
+	exit();
 } else {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 23, 3);

--- a/web/html/matPat/cadastro_produto.php
+++ b/web/html/matPat/cadastro_produto.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 if (session_status() === PHP_SESSION_NONE) {
 	session_start();
 }
@@ -13,8 +14,6 @@ if (!isset($_SESSION['usuario'])) {
 
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 permissao($_SESSION['id_pessoa'], 22, 3);
-
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 // Adiciona a Função display_campo($nome_campo, $tipo_campo)
 require_once ROOT . "/html/personalizacao_display.php";

--- a/web/html/matPat/cadastro_saida.php
+++ b/web/html/matPat/cadastro_saida.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -10,8 +11,6 @@ if (!isset($_SESSION['usuario'])) {
 } else {
 	session_regenerate_id();
 }
-
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 $id_pessoa = filter_var($_SESSION['id_pessoa'], FILTER_VALIDATE_INT);
 

--- a/web/html/matPat/estoque.php
+++ b/web/html/matPat/estoque.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 22, 5);

--- a/web/html/matPat/listar_Ientrada.php
+++ b/web/html/matPat/listar_Ientrada.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if(session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 23, 5);

--- a/web/html/matPat/listar_Isaida.php
+++ b/web/html/matPat/listar_Isaida.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 24, 5);

--- a/web/html/matPat/listar_categoria.php
+++ b/web/html/matPat/listar_categoria.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if(session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -18,7 +19,6 @@ if(!$id_pessoa) {
 	exit();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($id_pessoa, 22, 5);

--- a/web/html/matPat/listar_saida.php
+++ b/web/html/matPat/listar_saida.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
 	session_start();
@@ -11,7 +12,6 @@ if (!isset($_SESSION['usuario'])) {
 	session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 24, 5);

--- a/web/html/matPat/listar_unidade.php
+++ b/web/html/matPat/listar_unidade.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 if (session_status() === PHP_SESSION_NONE)
    session_start();
 
@@ -10,7 +11,6 @@ if (!isset($_SESSION['usuario'])) {
    session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 
 permissao($_SESSION['id_pessoa'], 22, 5);

--- a/web/html/pet/profile_pet.php
+++ b/web/html/pet/profile_pet.php
@@ -1,4 +1,5 @@
 <?php
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'Util.php';
 Util::definirFusoHorario();
 if (session_status() === PHP_SESSION_NONE) {
@@ -31,8 +32,6 @@ if (!isset($_SESSION['pet'])) {
   $pet = json_encode($petDados);
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'Util.php';
 require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'Csrf.php';
 
 require_once "../personalizacao_display.php";

--- a/web/html/voluntario/pre_cadastro_voluntario.php
+++ b/web/html/voluntario/pre_cadastro_voluntario.php
@@ -1,5 +1,6 @@
 <?php
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'seguranca' . DIRECTORY_SEPARATOR . 'security_headers.php';
+require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 
 if (session_status() === PHP_SESSION_NONE)
     session_start();
@@ -12,7 +13,6 @@ else {
     session_regenerate_id();
 }
 
-require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'config.php';
 require_once dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'permissao' . DIRECTORY_SEPARATOR . 'permissao.php';
 // Not checking specific permissions for this page, as volunteer forms don't always, but we could if we wanted.
 


### PR DESCRIPTION
## Problema

Em 18 arquivos, o `require_once` de `config.php` (que define a constante `WWW`) acontecia **depois** do bloco de autenticação que usa `WWW` dentro de `header("Location: " . WWW . ...)`.

Resultado: qualquer requisição **sem sessão válida** para esses arquivos gerava `Uncaught Error: Undefined constant "WWW"` (HTTP 500 — Fatal Error), em vez do redirecionamento limpo para a tela de login esperado.

Esse é o mesmo padrão de bug já corrigido em `listar_despachos.php` (PR #2006), encontrado ao testar ao vivo o `alterar_produto.php` (PR #2016). Depois de corrigi-lo lá, varri o restante da árvore `web/**/*.php` procurando o mesmo padrão (uso de `WWW` antes do `require` de `config.php`) e confirmei manualmente, arquivo por arquivo, os 17 casos restantes antes de aplicar a correção — só toquei nos casos onde a estrutura era idêntica ao bug confirmado.

## Correção

Mover o `require_once ... config.php` para antes do bloco `session_start()`/`if (!isset($_SESSION['usuario']))`, na mesma posição já usada em todo o resto do módulo.

Dois arquivos (`cadastro_entrada.php`, `documentos_funcionario.php`) tinham um segundo bug independente — `exit()` ausente após o `header("Location: ...")` — corrigido junto.

## Arquivos alterados

- `web/html/matPat/alterar_produto.php`
- `web/html/matPat/cadastro_entrada.php` (+ `exit()` ausente)
- `web/html/matPat/estoque.php`
- `web/html/matPat/listar_saida.php`
- `web/html/matPat/listar_categoria.php`
- `web/html/matPat/adicionar_unidade.php`
- `web/html/matPat/cadastro_produto.php`
- `web/html/matPat/cadastro_saida.php`
- `web/html/matPat/listar_Ientrada.php`
- `web/html/matPat/listar_Isaida.php`
- `web/html/matPat/listar_unidade.php`
- `web/html/geral/modulos_visiveis.php`
- `web/html/geral/cargos.php`
- `web/html/geral/listar_permissoes.php`
- `web/html/geral/documentos_funcionario.php` (+ `exit()` ausente)
- `web/html/pet/profile_pet.php`
- `web/html/funcionario/pre_cadastro_funcionario.php`
- `web/html/voluntario/pre_cadastro_voluntario.php`

## Testes

- `php -l` limpo em todos os 18 arquivos.
- Requisição sem sessão via curl para cada um dos 18 endpoints: todos retornam `302` (redirect limpo) — antes da correção, retornavam `500`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
