### PR TITLE
Fix: quem tem acesso ao módulo Permissões pode trocar senha de outra pessoa

### DIFF
--- a/web/controle/FuncionarioControle.php
+++ b/web/controle/FuncionarioControle.php
@@ -1309,15 +1309,19 @@ class FuncionarioControle
                 throw new InvalidArgumentException('Os campos de senha são obrigatórios.', 400);
             }
 
-            $funcionarioDAO = new FuncionarioDAO();
-
-            if ($id_pessoa != $_SESSION['id_pessoa'] && !$funcionarioDAO->verificaAdm($_SESSION['id_pessoa'])) {
-                throw new LogicException('Operação negada: O usuário logado não é o mesmo de que se deseja alterar a senha', 401);
+            // Trocar a senha de OUTRA pessoa exige acesso ao módulo de Permissões
+            // (recurso 91) -- o mesmo que já controla quem acessa
+            // geral/configurar_senhas.php. permissao() redireciona e encerra a
+            // execução caso o usuário logado não tenha essa permissão, então
+            // se chegarmos além desta linha é porque ele tem.
+            if ($id_pessoa != $_SESSION['id_pessoa']) {
+                require_once ROOT . '/html/permissao/permissao.php';
+                permissao($_SESSION['id_pessoa'], 91, 1);
             }
 
             $isConfigAdm = false;
 
-            if($id_pessoa == $_SESSION['id_pessoa'] && $funcionarioDAO->verificaAdm($_SESSION['id_pessoa']) && "geral/configurar_senhas.php" === $redir) {
+            if ($id_pessoa == $_SESSION['id_pessoa'] && "geral/configurar_senhas.php" === $redir) {
                 header("Location: " . WWW . "html/geral/configurar_senhas.php?verificacao=6");
                 exit();
             }
@@ -1334,8 +1338,8 @@ class FuncionarioControle
                 $sucesso     = 5;
 
             }
-            // --- Fluxo: admin configurando senha de outro usuário ---
-            elseif ($redir === "geral/configurar_senhas.php" && $funcionarioDAO->verificaAdm($_SESSION['id_pessoa'])) {
+            // --- Fluxo: pessoa com acesso ao módulo de Permissões configurando senha de outro usuário ---
+            elseif ($redir === "geral/configurar_senhas.php") {
 
                 $isConfigAdm = true;
                 $page        = $redir;

--- a/web/controle/FuncionarioControle.php
+++ b/web/controle/FuncionarioControle.php
@@ -767,7 +767,7 @@ class FuncionarioControle
             if ($senha_armazenada !== null) {
                 $check = LoginHelper::verifyAndMigrate($nova_senha, $senha_armazenada);
                 if ($check['valid']) {
-                    return 4; // nova senha igual à atual — bloqueado
+                    return 3; // nova senha igual à atual — bloqueado
                 }
             }
 
@@ -1292,6 +1292,20 @@ class FuncionarioControle
         $senha_antiga    = filter_input(INPUT_POST, 'senha_antiga');
         $redir           = filter_input(INPUT_POST, 'redir', FILTER_SANITIZE_SPECIAL_CHARS);
 
+        // Exibe qualquer erro deste fluxo como a faixa vermelha padrão do
+        // sistema (msg.php), em vez do JSON cru que o catch genérico do
+        // método devolve -- isso deixava a tela em branco pro usuário.
+        // Só redireciona de volta pra configurar_senhas.php quando foi de lá
+        // que a requisição veio; qualquer outro caso cai em home.php, pra
+        // não abrir um redirect aberto a partir do valor de 'redir' do POST.
+        $redirErro = function (string $mensagem) use ($redir) {
+            require_once ROOT . '/html/geral/msg.php';
+            setSessionMsg($mensagem, 'error');
+            $destino = ($redir === 'geral/configurar_senhas.php') ? $redir : 'home.php';
+            header('Location: ' . WWW . 'html/' . $destino);
+            exit();
+        };
+
         try {
             if (!Csrf::validateToken($_POST['csrf_token'] ?? '')) {
                 throw new InvalidArgumentException('O Token CSRF informado é inválido.', 403);
@@ -1317,13 +1331,19 @@ class FuncionarioControle
             if ($id_pessoa != $_SESSION['id_pessoa']) {
                 require_once ROOT . '/html/permissao/permissao.php';
                 permissao($_SESSION['id_pessoa'], 91, 1);
+
+                // A senha do usuário adm_configurado=1 nunca pode ser trocada
+                // por este fluxo, mesmo por quem tem acesso ao módulo de
+                // Permissões -- só o próprio dono da conta pode trocá-la,
+                // e não por este painel (bloqueio de auto-troca acima).
+                $funcionarioDAO = new FuncionarioDAO();
+                if ($funcionarioDAO->verificaAdm($id_pessoa)) {
+                    $redirErro('A senha desse usuário só pode ser trocada por ele mesmo.');
+                }
             }
 
-            $isConfigAdm = false;
-
             if ($id_pessoa == $_SESSION['id_pessoa'] && "geral/configurar_senhas.php" === $redir) {
-                header("Location: " . WWW . "html/geral/configurar_senhas.php?verificacao=6");
-                exit();
+                $redirErro('Operação negada: Administradores não podem alterar a própria senha pelo painel de configuração de senhas. Por favor, utilize a opção de alteração de senha no menu do usuário.');
             }
 
             // --- Fluxo: usuário trocando a própria senha ---
@@ -1333,37 +1353,50 @@ class FuncionarioControle
                     throw new InvalidArgumentException('A senha atual é obrigatória.', 400);
                 }
 
-                $page        = "logout.php";
                 $verificacao = $this->verificarSenha($nova_senha, $confirmar_senha, $id_pessoa, $senha_antiga);
-                $sucesso     = 5;
+
+                // Continua usando o parâmetro numérico ?verificacao=N em
+                // logout.php -- esse fluxo redireciona pra fora da sessão
+                // (a página não tem faixa vermelha, é só o alert() de sempre).
+                header("Location: " . WWW . "html/logout.php?verificacao=" . htmlspecialchars($verificacao));
+                exit();
 
             }
             // --- Fluxo: pessoa com acesso ao módulo de Permissões configurando senha de outro usuário ---
             elseif ($redir === "geral/configurar_senhas.php") {
 
-                $isConfigAdm = true;
-                $page        = $redir;
                 $verificacao = $this->verificarSenhaConfig($nova_senha, $confirmar_senha, $id_pessoa);
-                $sucesso     = 4;
+
+                if ($verificacao === 4) {
+                    require_once ROOT . '/html/geral/msg.php';
+                    setSessionMsg('Senha alterada com sucesso!', 'success');
+                    header("Location: " . WWW . "html/geral/configurar_senhas.php");
+                    exit();
+                }
+
+                $mensagensConfig = [
+                    1 => 'Campos obrigatórios ausentes ou inválidos.',
+                    2 => 'Nova senha e confirmação não conferem.',
+                    3 => 'A nova senha não pode ser igual à senha atual.',
+                ];
+
+                $redirErro($mensagensConfig[$verificacao] ?? 'Não foi possível alterar a senha.');
 
             }
             else {
                 throw new LogicException('Rota de alteração de senha não reconhecida para este usuário.', 400);
             }
 
-            // Monta a URL de redirecionamento
-            $url = WWW . 'html/' . htmlspecialchars($page) . '?verificacao=' . htmlspecialchars($verificacao);
-
-            // Só o fluxo de admin usa o parâmetro extra, e só em caso de sucesso
-            if ($isConfigAdm && $verificacao == $sucesso) {
-                $url .= '&redir_config=true';
-            }
-
-            header("Location: " . $url);
-            exit();
-
         } catch (Exception $e) {
-            Util::tratarException($e);
+            error_log($e->__toString());
+            // PDOException pode expor detalhes internos do banco (nomes de
+            // tabela/coluna) na mensagem -- não repassa pro usuário, igual o
+            // Util::tratarException já fazia antes desta função passar a usar
+            // o redirect com faixa vermelha em vez de JSON cru.
+            $mensagem = $e instanceof PDOException
+                ? 'Erro interno ao acessar o banco de dados.'
+                : $e->getMessage();
+            $redirErro($mensagem);
         }
     }
 

--- a/web/html/geral/configurar_senhas.php
+++ b/web/html/geral/configurar_senhas.php
@@ -40,6 +40,7 @@ try {
 // Adiciona a Função display_campo($nome_campo, $tipo_campo)
 require_once ROOT . "/html/personalizacao_display.php";
 require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_SEPARATOR . 'Csrf.php';
+require_once dirname(__FILE__) . DIRECTORY_SEPARATOR . 'msg.php';
 
 ?>
 <!doctype html>
@@ -111,37 +112,6 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
 		});
 	</script>
 
-<script>
-	$(function() {
-		const verificacao = '<?= isset($_GET['verificacao']) ? htmlspecialchars($_GET['verificacao']) : '0' ?>';
-
-		switch (verificacao) {
-			case '0':
-				break;
-			case '1':
-				alert("Campos obrigatórios ausentes ou inválidos");
-				break;
-			case '2':
-				alert("Nova senha e confirmação não conferem");
-				break;
-			case '3':
-				alert("Senha atual informada está incorreta");
-				break;
-			case '4':
-				alert('Senha alterada com sucesso!');
-				break;
-			case '5':
-				alert('Senha alterada com sucesso!');
-				break;
-				case '6':
-				alert('Operação negada: Administradores não podem alterar a própria senha pelo painel de configuração de senhas. Por favor, utilize a opção de alteração de senha no menu do usuário.');
-				break;
-			default:
-				alert("O valor informado para a verificação não é válido.");
-		}
-	});
-</script>
-
 </head>
 
 <body>
@@ -174,6 +144,12 @@ require_once dirname(__FILE__, 3) . DIRECTORY_SEPARATOR . 'classes' . DIRECTORY_
 				</header>
 
 				<!-- start: page -->
+				<div class="row">
+					<div id="message-container" class="col-md-12">
+						<?php displayMsg();
+						sessionMsg(); ?>
+					</div>
+				</div>
 				<div class="row">
 					<div class="col-md-4 col-lg-3">
 						<section class="panel"></section>


### PR DESCRIPTION
## Resumo

Corrige um bug real de produção, confirmado via log de erro:

```
LogicException: Operação negada: O usuário logado não é o mesmo de que se deseja alterar a senha
in web/controle/FuncionarioControle.php:1315
```

## Causa raiz

`FuncionarioControle::alterarSenha()` exigia a flag especial `pessoa.adm_configurado=1` (separada do cargo) para permitir trocar a senha de **outra** pessoa. Essa flag é totalmente independente do cargo/função da pessoa — e **não existe nenhuma tela no sistema para concedê-la a uma segunda conta**; o único jeito é um `UPDATE` direto no banco.

Isso significa: uma pessoa com o cargo "Administrador" (que já tem acesso normal a `geral/configurar_senhas.php` via `permissao(91,1)`) mas sem `adm_configurado=1` tentava trocar a senha de outro funcionário e recebia a exceção acima — jogada como **JSON cru na tela** (não um erro amigável), já que a exceção sobe direto pro catch genérico do método.

Reproduzi localmente com precisão: cargo "Administrador" + `adm_configurado=0`, tentando alterar a senha de outra pessoa → mesma `LogicException`.

## Fix

Troca a checagem de `verificaAdm()` (a flag separada `adm_configurado`) por `permissao($_SESSION['id_pessoa'], 91, 1)` — o mesmo recurso que já controla o acesso à própria tela de configuração de senhas. Já que `permissao()` lida com a própria negação (redirect amigável + mensagem, em vez de exceção crua), a checagem "quem pode trocar a senha de outra pessoa" agora usa exatamente a mesma régua de "quem pode acessar essa tela", eliminando a necessidade da flag `adm_configurado` nesse fluxo específico (mantida intacta para os outros usos dela: `profile_funcionario.php` — controle de quem pode editar cargo de outro admin — e `login.php`, ambos inalterados neste PR).

## Atualizações (revisão)

Depois da revisão inicial, dois ajustes de segurança/UX foram adicionados ao mesmo fluxo:

1. **Protege a senha do usuário `adm_configurado=1`**: como qualquer pessoa com acesso ao módulo de Permissões agora pode trocar a senha de outro funcionário, foi adicionado um bloqueio explícito para que a senha de quem tem `adm_configurado=1` nunca possa ser trocada por esse painel — só o próprio dono da conta pode trocá-la (via troca da própria senha, não pelo painel de admin).
2. **Unifica a exibição de erros em `configurar_senhas.php`**: todo erro desse fluxo (CSRF inválido, campos ausentes/obrigatórios, senha fora da política, senha repetida, bloqueio do item 1, etc.) antes ou caía em JSON cru (tela em branco) via `Util::tratarException`, ou aparecia como `alert()` de JS baseado em `?verificacao=N`. Agora todos usam o mesmo mecanismo de faixa vermelha (`msg.php`/`setSessionMsg`) já usado em outras telas do sistema (ex: `home.php`). O switch de JS morto foi removido. De quebra, corrigiu um bug em `verificarSenhaConfig()` onde "senha igual à atual" e "sucesso" retornavam o mesmo código (`4`).

## Test plan

- [x] Cargo "Administrador" sem `adm_configurado`, trocando senha de outra pessoa → sucesso (antes: erro)
- [x] Sem permissão nenhuma no módulo Permissões, tentando o mesmo, direto no controller (contornando o gate da própria página) → bloqueado com redirect amigável pra `home.php`, senha do alvo intacta
- [x] Bloqueio de "não pode trocar a própria senha por este painel" continua funcionando, agora pra qualquer um com acesso ao módulo, não só quem tinha `adm_configurado` — exibido como faixa vermelha
- [x] Tentar trocar a senha do usuário `adm_configurado=1` → bloqueado com faixa vermelha, senha intacta
- [x] Campos vazios, senhas não conferem, senha repetida, senha fora da política, CSRF inválido → todos exibidos como faixa vermelha em `configurar_senhas.php`
- [x] `php -l` limpo nos dois arquivos alterados

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7Qyc2RYAfURLqVpPTiMz8